### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,5 +1,8 @@
 name: Python tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/NicklasAndersson/oden/security/code-scanning/3](https://github.com/NicklasAndersson/oden/security/code-scanning/3)

In general, fix this by explicitly specifying a `permissions` block that grants only the minimal required scopes for the workflow. You can define it at the root (applies to all jobs) or per job (if different jobs need different scopes). For this workflow, both `lint` and `test` only need to read the repository contents; `codecov/codecov-action` uploads coverage to Codecov’s service and does not need to write to the GitHub repo. So we can safely set `permissions: contents: read`.

The single best fix with no behavior change is to add a top-level `permissions` block right after the `name:` (before `on:`). This will ensure both `lint` and `test` jobs run with `GITHUB_TOKEN` limited to `contents: read`. No other scopes (issues, pull-requests, statuses, checks) are necessary based on the shown steps. No imports or additional methods are required because this is a YAML workflow change only.

Concretely: edit `.github/workflows/python-test.yml`, and between line 1 (`name: Python tests`) and line 3 (`on:`), insert:

```yaml
permissions:
  contents: read
```

This will satisfy CodeQL by explicitly constraining `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
