### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/NicklasAndersson/oden/security/code-scanning/1](https://github.com/NicklasAndersson/oden/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the job (or at the workflow root) that limits the `GITHUB_TOKEN` to the minimal scopes needed. For the `build` job, it only needs read access to repository contents to perform `actions/checkout` and to access code; upload-artifact uses its own permissions and does not require write access to repository contents.

The best fix with minimal functional impact is to add `permissions: contents: read` to the `build` job definition. This keeps the existing `package-and-release` job’s `contents: write` unchanged (it needs that to create a GitHub Release) while constraining the `build` job’s token. No imports or additional methods are needed since this is just a YAML configuration change in `.github/workflows/release.yml`.

Concretely:
- In `.github/workflows/release.yml`, under `jobs: build:`, insert:

```yaml
    permissions:
      contents: read
```

right after `runs-on: ${{ matrix.os }}` (or before `strategy:`). Leave the existing `permissions` block under `package-and-release` as-is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
