### PR TITLE
fix: inject libsignal_jni.so for ARM64 Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
 
 # Download and install signal-cli
 ARG SIGNAL_CLI_VERSION=0.14.1
+ARG LIBSIGNAL_CLIENT_VERSION=0.87.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     curl -sL "https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz" \
@@ -33,6 +34,23 @@ RUN apt-get update && \
     apt-get purge -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
+# Fix: upstream signal-cli JAR lacks libsignal_jni.so for Linux ARM64.
+# Download pre-built native library and inject it into the JAR.
+# Source: https://github.com/bbernhard/signal-cli-rest-api
+RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        python3 -c "\
+import urllib.request, zipfile, os; \
+url = 'https://github.com/bbernhard/signal-cli-rest-api/raw/master/ext/libraries/libsignal-client/v${LIBSIGNAL_CLIENT_VERSION}/arm64/libsignal_jni.so'; \
+so = '/tmp/libsignal_jni.so'; \
+jar = '/opt/signal-cli/lib/libsignal-client-${LIBSIGNAL_CLIENT_VERSION}.jar'; \
+urllib.request.urlretrieve(url, so); \
+zf = zipfile.ZipFile(jar, 'a'); \
+zf.write(so, 'libsignal_jni.so'); \
+zf.close(); \
+os.remove(so); \
+print('Injected libsignal_jni.so for arm64')"; \
+    fi
 
 # Set up application
 WORKDIR /app


### PR DESCRIPTION
## Problem

The upstream libsignal-client-0.87.4.jar bundled with signal-cli 0.14.1 contains native JNI libraries for Linux x86_64, macOS ARM64, macOS x86_64, and Windows x86_64 — but **no libsignal_jni.so for Linux ARM64**. This causes signal-cli to fail with:

```
WARN Manager - Failed to call libsignal-client: no signal_jni in java.library.path
```

This breaks the Docker setup wizard on Apple Silicon Macs (and any ARM64 Linux host).

## Fix

Add a build step that detects ARM64 (dpkg --print-architecture) and downloads a pre-built libsignal_jni.so from [bbernhard/signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api), then injects it into the JAR using Python zipfile. The step is a no-op on x86_64 builds.

LIBSIGNAL_CLIENT_VERSION is pinned to 0.87.4 (matching the JAR shipped with signal-cli 0.14.1) and should be bumped alongside SIGNAL_CLI_VERSION when upgrading.

## Verified locally

- docker build succeeds (44s, injection step runs on ARM64)
- signal-cli --version returns signal-cli 0.14.1 (previously failed with no signal_jni)
- signal-cli link outputs valid sgnl:// URI (previously crashed)

## Files changed

| File | Change |
|------|--------|
| Dockerfile | Add LIBSIGNAL_CLIENT_VERSION arg and ARM64 native library injection step |

All 225 tests pass. Lint and format clean.