### PR TITLE
Fix stale account recovery and Windows signal-cli path discovery

### DIFF
--- a/oden/signal_manager.py
+++ b/oden/signal_manager.py
@@ -55,14 +55,23 @@ def get_bundled_signal_cli_path() -> str | None:
 def _get_standard_signal_cli_paths() -> list[Path]:
     """Return standard signal-cli data directory paths for the current platform."""
     paths: list[Path] = []
+
     if sys.platform == "win32":
         local_app_data = os.environ.get("LOCALAPPDATA", "")
         if local_app_data:
             paths.append(Path(local_app_data) / "signal-cli")
-    else:
-        # macOS and Linux both use ~/.local/share/signal-cli
-        paths.append(Path.home() / ".local" / "share" / "signal-cli")
-    return paths
+
+    # signal-cli commonly uses ~/.local/share/signal-cli on macOS/Linux,
+    # and some Windows installs do the same through Java path defaults.
+    paths.append(Path.home() / ".local" / "share" / "signal-cli")
+
+    deduped_paths: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            deduped_paths.append(path)
+    return deduped_paths
 
 
 def get_signal_data_search_paths() -> list[Path]:

--- a/oden/templates/web/js/dashboard/accounts.js
+++ b/oden/templates/web/js/dashboard/accounts.js
@@ -35,7 +35,7 @@ async function loadAccounts() {
         if (!activeValid && data.active_number && connected) {
             warning.classList.remove('hidden');
             document.getElementById('accounts-warning-text').textContent =
-                'Det konfigurerade kontot (' + escapeHtml(data.active_number) + ') finns inte bland de tillgängliga kontona. Välj ett giltigt konto eller lägg till ett nytt.';
+                'Det konfigurerade kontot (' + escapeHtml(data.active_number) + ') finns inte bland de tillgängliga kontona. Radera den trasiga kontoposten eller välj ett giltigt konto.';
         } else {
             warning.classList.add('hidden');
         }
@@ -49,9 +49,12 @@ async function loadAccounts() {
         for (const acc of accounts) {
             const num = acc.number;
             const isActive = acc.active;
+            const isStale = !!acc.stale;
 
             const row = document.createElement('div');
-            row.style.cssText = 'display: flex; align-items: center; justify-content: space-between; padding: 12px 15px; border: 1px solid ' + (isActive ? '#2e7d32' : '#333') + '; border-radius: 8px; margin-bottom: 8px; background: ' + (isActive ? '#1a3a1a' : '#16213e') + ';';
+            const borderColor = isStale ? '#c62828' : (isActive ? '#2e7d32' : '#333');
+            const backgroundColor = isStale ? '#3a1616' : (isActive ? '#1a3a1a' : '#16213e');
+            row.style.cssText = 'display: flex; align-items: center; justify-content: space-between; padding: 12px 15px; border: 1px solid ' + borderColor + '; border-radius: 8px; margin-bottom: 8px; background: ' + backgroundColor + ';';
 
             const info = document.createElement('div');
             const strong = document.createElement('strong');
@@ -61,26 +64,32 @@ async function loadAccounts() {
 
             if (isActive) {
                 const badge = document.createElement('span');
-                badge.style.cssText = 'color: #4caf50; font-size: 0.9em; margin-left: 8px;';
-                badge.textContent = '● Aktivt konto';
+                badge.style.cssText = 'color: ' + (isStale ? '#ff8a80' : '#4caf50') + '; font-size: 0.9em; margin-left: 8px;';
+                badge.textContent = isStale ? '● Aktivt konto saknas på disk' : '● Aktivt konto';
                 info.appendChild(badge);
             }
 
             const actions = document.createElement('div');
             actions.style.cssText = 'display: flex; gap: 8px;';
 
-            if (!isActive) {
+            if (!isActive || isStale) {
                 const useBtn = document.createElement('button');
-                useBtn.className = 'btn btn-primary';
-                useBtn.style.cssText = 'padding: 5px 12px; font-size: 0.85em;';
-                useBtn.textContent = 'Använd';
-                useBtn.addEventListener('click', () => activateAccount(num));
+                if (!isActive) {
+                    useBtn.className = 'btn btn-primary';
+                    useBtn.style.cssText = 'padding: 5px 12px; font-size: 0.85em;';
+                    useBtn.textContent = 'Använd';
+                    useBtn.addEventListener('click', () => activateAccount(num));
+                    actions.appendChild(useBtn);
+                }
 
-                const delBtn = document.createElement('button');
-                delBtn.className = 'btn btn-secondary';
-                delBtn.style.cssText = 'padding: 5px 12px; font-size: 0.85em;';
-                delBtn.textContent = 'Radera';
-                delBtn.addEventListener('click', () => deleteAccount(num));
+                if (connected) {
+                    const delBtn = document.createElement('button');
+                    delBtn.className = 'btn btn-secondary';
+                    delBtn.style.cssText = 'padding: 5px 12px; font-size: 0.85em;';
+                    delBtn.textContent = 'Radera';
+                    delBtn.addEventListener('click', () => deleteAccount(num));
+                    actions.appendChild(delBtn);
+                }
 
                 const forceBtn = document.createElement('button');
                 forceBtn.className = 'btn btn-secondary';
@@ -88,8 +97,6 @@ async function loadAccounts() {
                 forceBtn.textContent = 'Tvinga radering';
                 forceBtn.addEventListener('click', () => forceDeleteAccount(num));
 
-                actions.appendChild(useBtn);
-                actions.appendChild(delBtn);
                 actions.appendChild(forceBtn);
             } else {
                 const note = document.createElement('span');

--- a/oden/web_handlers/account_handlers.py
+++ b/oden/web_handlers/account_handlers.py
@@ -32,6 +32,17 @@ logger = logging.getLogger(__name__)
 _finish_link_task: asyncio.Task | None = None
 
 
+def _is_stale_configured_account(number: str, accounts: list[dict] | None = None) -> bool:
+    """Return True when *number* is configured but not present on disk."""
+    if not number or number != cfg.SIGNAL_NUMBER:
+        return False
+
+    if accounts is None:
+        accounts = get_existing_accounts()
+
+    return not any(account.get("number") == number for account in accounts)
+
+
 async def accounts_list_handler(request: web.Request) -> web.Response:
     """List all signal-cli accounts and mark the active one.
 
@@ -40,17 +51,21 @@ async def accounts_list_handler(request: web.Request) -> web.Response:
     """
     app_state = get_app_state()
 
+    existing_accounts = get_existing_accounts()
     accounts = []
     active_number = cfg.SIGNAL_NUMBER
     connected = bool(app_state.writer)
 
-    for account in get_existing_accounts():
+    for account in existing_accounts:
         number = account.get("number")
         if number:
             accounts.append({"number": number, "active": number == active_number})
 
     # Check if active account is valid
     active_valid = any(a["active"] for a in accounts)
+
+    if active_number and not active_valid:
+        accounts.insert(0, {"number": active_number, "active": True, "stale": True})
 
     return web.json_response(
         {
@@ -299,11 +314,21 @@ async def accounts_delete_handler(request: web.Request) -> web.Response:
             status=400,
         )
 
-    # Prevent deleting the active account without switching first
-    if number == cfg.SIGNAL_NUMBER:
+    accounts = get_existing_accounts()
+    is_stale_active = _is_stale_configured_account(number, accounts)
+
+    # Prevent deleting the active account without switching first,
+    # but allow recovery when the configured account is already stale.
+    if number == cfg.SIGNAL_NUMBER and not is_stale_active:
         return web.json_response(
             {"success": False, "error": "Kan inte radera det aktiva kontot. Byt konto först."},
             status=400,
+        )
+
+    if is_stale_active:
+        logger.warning(
+            "Allowing deletion of configured account %s because it is no longer present on disk",
+            number,
         )
 
     app_state = get_app_state()
@@ -349,10 +374,19 @@ async def accounts_force_delete_handler(request: web.Request) -> web.Response:
             status=400,
         )
 
-    if number == cfg.SIGNAL_NUMBER:
+    accounts = get_existing_accounts()
+    is_stale_active = _is_stale_configured_account(number, accounts)
+
+    if number == cfg.SIGNAL_NUMBER and not is_stale_active:
         return web.json_response(
             {"success": False, "error": "Kan inte radera det aktiva kontot. Byt konto först."},
             status=400,
+        )
+
+    if is_stale_active:
+        logger.warning(
+            "Allowing force-delete of configured account %s because it is no longer present on disk",
+            number,
         )
 
     if not _remove_account_from_disk(number):

--- a/tests/test_s7_watcher.py
+++ b/tests/test_s7_watcher.py
@@ -174,6 +174,27 @@ class TestSignalManager(unittest.TestCase):
 
         self.assertEqual(command, ["cmd.exe", "/c", executable, "daemon"])
 
+    def test_get_standard_signal_cli_paths_windows_includes_home_share_path(self, mock_find_executable):
+        """Windows installs may store accounts under ~/.local/share/signal-cli."""
+        from pathlib import Path
+
+        from oden.signal_manager import _get_standard_signal_cli_paths
+
+        with (
+            patch("oden.signal_manager.sys.platform", "win32"),
+            patch.dict("oden.signal_manager.os.environ", {"LOCALAPPDATA": r"C:\\Users\\Nicklas\\AppData\\Local"}),
+            patch("oden.signal_manager.Path.home", return_value=Path(r"C:\\Users\\Nicklas")),
+        ):
+            paths = _get_standard_signal_cli_paths()
+
+        self.assertEqual(
+            paths,
+            [
+                Path(r"C:\\Users\\Nicklas\\AppData\\Local") / "signal-cli",
+                Path(r"C:\\Users\\Nicklas") / ".local" / "share" / "signal-cli",
+            ],
+        )
+
 
 class TestIsSignalCliRunning(unittest.TestCase):
     @patch("socket.socket")

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -90,6 +90,29 @@ class TestAccountManagementAPI(AioHTTPTestCase):
         self.assertEqual(data["accounts"], [{"number": "+46701111111", "active": True}])
         self.assertTrue(data["connected"])
 
+    @unittest.mock.patch("oden.web_handlers.account_handlers.get_app_state")
+    @unittest.mock.patch(
+        "oden.web_handlers.account_handlers.get_existing_accounts",
+        return_value=[],
+    )
+    async def test_api_accounts_includes_stale_active_account_for_recovery(
+        self,
+        mock_get_existing_accounts,
+        mock_get_app_state,
+    ):
+        mock_get_app_state.return_value.writer = object()
+
+        with unittest.mock.patch("oden.web_handlers.account_handlers.cfg.SIGNAL_NUMBER", "+46701111111"):
+            resp = await self.client.get("/api/accounts")
+
+        self.assertEqual(resp.status, 200)
+        data = await resp.json()
+        self.assertEqual(
+            data["accounts"],
+            [{"number": "+46701111111", "active": True, "stale": True}],
+        )
+        self.assertFalse(data["active_valid"])
+
     async def test_force_delete_removes_account_from_all_known_stores(self):
         number = "+46702222222"
 
@@ -168,6 +191,85 @@ class TestAccountManagementAPI(AioHTTPTestCase):
                     return_value=[store],
                 ),
                 unittest.mock.patch("oden.web_handlers.account_handlers.cfg.SIGNAL_NUMBER", "+46709999999"),
+            ):
+                resp = await self.client.delete(f"/api/accounts/{number}")
+
+            self.assertEqual(resp.status, 200)
+            data = await resp.json()
+            self.assertTrue(data["success"])
+            self.assertEqual(json.loads(accounts_file.read_text())["accounts"], [])
+            self.assertFalse(account_dir.exists())
+
+    @unittest.mock.patch("oden.web_handlers.account_handlers.get_existing_accounts", return_value=[])
+    async def test_force_delete_allows_stale_configured_account(self, mock_get_existing_accounts):
+        number = "+46704444444"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = Path(tmpdir) / "store"
+            account_dir = store / "data" / "acct-a"
+            account_dir.mkdir(parents=True)
+            accounts_file = store / "data" / "accounts.json"
+            accounts_file.write_text(
+                json.dumps(
+                    {
+                        "accounts": [
+                            {"number": number, "path": "acct-a"},
+                        ]
+                    }
+                )
+            )
+
+            with (
+                unittest.mock.patch(
+                    "oden.web_handlers.account_handlers.get_signal_data_search_paths",
+                    return_value=[store],
+                ),
+                unittest.mock.patch("oden.web_handlers.account_handlers.cfg.SIGNAL_NUMBER", number),
+            ):
+                resp = await self.client.delete(f"/api/accounts/{number}/force")
+
+        self.assertEqual(resp.status, 200)
+        data = await resp.json()
+        self.assertTrue(data["success"])
+
+    @unittest.mock.patch("oden.web_handlers.account_handlers.get_app_state")
+    @unittest.mock.patch("oden.web_handlers._helpers.get_app_state")
+    @unittest.mock.patch("oden.web_handlers.account_handlers.get_existing_accounts", return_value=[])
+    async def test_delete_account_allows_stale_configured_account(
+        self,
+        mock_get_existing_accounts,
+        mock_require_writer_state,
+        mock_handler_state,
+    ):
+        number = "+46705555555"
+
+        state = unittest.mock.Mock()
+        state.writer = object()
+        state.send_jsonrpc = unittest.mock.AsyncMock(return_value={"result": {}})
+        mock_require_writer_state.return_value = state
+        mock_handler_state.return_value = state
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = Path(tmpdir) / "store"
+            account_dir = store / "data" / "acct-a"
+            account_dir.mkdir(parents=True)
+            accounts_file = store / "data" / "accounts.json"
+            accounts_file.write_text(
+                json.dumps(
+                    {
+                        "accounts": [
+                            {"number": number, "path": "acct-a"},
+                        ]
+                    }
+                )
+            )
+
+            with (
+                unittest.mock.patch(
+                    "oden.web_handlers.account_handlers.get_signal_data_search_paths",
+                    return_value=[store],
+                ),
+                unittest.mock.patch("oden.web_handlers.account_handlers.cfg.SIGNAL_NUMBER", number),
             ):
                 resp = await self.client.delete(f"/api/accounts/{number}")
 


### PR DESCRIPTION
- Expose stale configured accounts (on-disk not found) in /api/accounts with a 'stale: true' flag so the UI can render a recovery row.
- Allow delete and force-delete for the active account when it is stale (i.e. configured but no longer present on disk), unblocking the 'already exists' re-link loop.
- Expand _get_standard_signal_cli_paths() to always include ~/.local/share/signal-cli on all platforms (including Windows), fixing the case where signal-cli stores data there but Oden only scanned %LOCALAPPDATA%\signal-cli.
- UI: stale row shown with red border and 'Force delete' button; normal 'Använd' and 'Radera' buttons hidden since the account has no disk data.
- Add regression tests for stale recovery API and Windows path discovery.