### PR TITLE
chore: upgrade signal-cli from 0.14.1 to 0.14.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build-dmg/signal-cli
-          key: signal-cli-0.14.1-v1
+          key: signal-cli-0.14.4.1-v1
 
       # Download JRE x64 (for Intel build - works via Rosetta on Apple Silicon)
       - name: Download JRE x64
@@ -88,7 +88,7 @@ jobs:
         if: steps.cache-signal-cli.outputs.cache-hit != 'true'
         run: |
           mkdir -p build-dmg/signal-cli
-          SIGNAL_CLI_VERSION="0.14.1"
+          SIGNAL_CLI_VERSION="0.14.4.1"
           curl -L -o signal-cli.tar.gz "https://github.com/AsamK/signal-cli/releases/download/v${SIGNAL_CLI_VERSION}/signal-cli-${SIGNAL_CLI_VERSION}.tar.gz"
           tar -xzf signal-cli.tar.gz
           mv signal-cli-${SIGNAL_CLI_VERSION}/* build-dmg/signal-cli/
@@ -269,7 +269,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build-win/signal-cli
-          key: signal-cli-0.14.1-windows-v1
+          key: signal-cli-0.14.4.1-windows-v1
 
       - name: Download JRE x64
         if: steps.cache-jre-x64-win.outputs.cache-hit != 'true'
@@ -291,7 +291,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path build-win/signal-cli | Out-Null
-          $signalCliVersion = "0.14.1"
+          $signalCliVersion = "0.14.4.1"
           $signalCliUrl = "https://github.com/AsamK/signal-cli/releases/download/v$signalCliVersion/signal-cli-$signalCliVersion.tar.gz"
           Invoke-WebRequest -Uri $signalCliUrl -OutFile signal-cli.tar.gz
           tar -xzf signal-cli.tar.gz -C build-win

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Download and install signal-cli
-ARG SIGNAL_CLI_VERSION=0.14.1
+ARG SIGNAL_CLI_VERSION=0.14.4.1
 ARG LIBSIGNAL_CLIENT_VERSION=0.87.4
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \

--- a/oden/signal_manager.py
+++ b/oden/signal_manager.py
@@ -206,7 +206,7 @@ def find_signal_cli_executable() -> str:
         return path
 
     # Check for signal-cli in project directory (development)
-    for version in ["0.14.1", "0.13.23"]:
+    for version in ["0.14.4.1", "0.14.1", "0.13.23"]:
         if sys.platform == "win32":
             dev_candidates = [
                 f"./signal-cli-{version}/bin/signal-cli.bat",

--- a/scripts/build_universal_dmg.sh
+++ b/scripts/build_universal_dmg.sh
@@ -4,7 +4,7 @@
 # =============================================================================
 # This script builds a universal macOS app bundle with:
 # - Bundled JRE 25 for both arm64 and x64
-# - Bundled signal-cli 0.14.1
+# - Bundled signal-cli 0.14.4.1
 # - Creates a DMG installer with Applications link
 #
 # Requirements:
@@ -19,7 +19,7 @@
 set -e
 
 # Configuration
-SIGNAL_CLI_VERSION="0.14.1"
+SIGNAL_CLI_VERSION="0.14.4.1"
 JRE_VERSION="25"
 JRE_VENDOR="eclipse"
 

--- a/scripts/run_mac.sh
+++ b/scripts/run_mac.sh
@@ -15,7 +15,7 @@ C_BOLD='\033[1m'
 C_YELLOW='\033[0;33m'
 
 # --- Configuration ---
-SIGNAL_CLI_VERSION="0.14.1"
+SIGNAL_CLI_VERSION="0.14.4.1"
 ODEN_CONFIG_DIR="$HOME/.oden"
 
 # macOS binary (universal - works on both Intel and Apple Silicon)


### PR DESCRIPTION
Fixes startup crash introduced in 0.14.4. Updates all version references in Dockerfile, CI workflows, build scripts, and the bundled signal-cli fallback detection list.