### PR TITLE
Add group suggestions to pipeline group filter

### DIFF
--- a/oden/templates/web/js/dashboard/pipelines.js
+++ b/oden/templates/web/js/dashboard/pipelines.js
@@ -27,6 +27,13 @@ function renderGroupFilterSettings(item) {
     const cfg = item.config || {};
     const mode = cfg.mode === 'whitelist' ? 'whitelist' : 'blacklist';
     const groups = Array.isArray(cfg.groups) ? cfg.groups : [];
+    const knownGroups = getKnownGroupNames();
+    const suggestionsHtml = knownGroups.length
+        ? knownGroups.map(groupName => {
+            const isSelected = groups.includes(groupName);
+            return `<button type="button" class="btn btn-small ${isSelected ? 'btn-secondary' : ''}" data-group-name="${escapeHtml(groupName)}" onclick="addGroupFilterGroupFromButton(this)">${escapeHtml(groupName)}</button>`;
+        }).join('')
+        : '<span class="text-muted">Inga kända grupper ännu.</span>';
 
     return `
         <div class="pipeline-settings">
@@ -40,12 +47,51 @@ function renderGroupFilterSettings(item) {
             <div class="pipeline-settings-row">
                 <label for="pipeline-config-group_filter-groups">Grupper (en per rad)</label>
                 <textarea id="pipeline-config-group_filter-groups" rows="4" placeholder="Exempelgrupp A\nExempelgrupp B">${escapeHtml(groups.join('\n'))}</textarea>
+                <div class="refresh-info" style="margin-top: 8px;">
+                    Förslag från befintliga grupper (klicka för att lägga till):
+                </div>
+                <div class="pipeline-suggestions" style="display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px;">
+                    ${suggestionsHtml}
+                </div>
+                <div class="refresh-info" style="margin-top: 6px;">
+                    Du kan också skriva egna gruppnamn som ännu inte finns.
+                </div>
             </div>
             <div class="pipeline-settings-actions">
                 <button class="btn btn-small" onclick="saveGroupFilterSettings()">Spara filter</button>
             </div>
         </div>
     `;
+}
+
+function getKnownGroupNames() {
+    const source = Array.isArray(_groupsCache) ? _groupsCache : [];
+    const names = source
+        .map(group => (group?.name || '').trim())
+        .filter(Boolean);
+    return [...new Set(names)].sort((a, b) => a.localeCompare(b, 'sv'));
+}
+
+function addGroupFilterGroupFromButton(button) {
+    addGroupFilterGroup(button?.dataset?.groupName || '');
+}
+
+function addGroupFilterGroup(groupName) {
+    const groupsEl = document.getElementById('pipeline-config-group_filter-groups');
+    const normalized = (groupName || '').trim();
+    if (!groupsEl || !normalized) {
+        return;
+    }
+
+    const groups = groupsEl.value
+        .split('\n')
+        .map(item => item.trim())
+        .filter(Boolean);
+
+    if (!groups.includes(normalized)) {
+        groups.push(normalized);
+        groupsEl.value = groups.join('\n');
+    }
 }
 
 function renderEnabledPipelines() {

--- a/scripts/install_snapshot_mac.sh
+++ b/scripts/install_snapshot_mac.sh
@@ -200,10 +200,10 @@ choose_snapshot_tag() {
     fi
 
     if [[ "$ODEN_SNAPSHOT_SELECT" == "ask" ]] && has_prompt_tty; then
-        print_info "Välj snapshot-version (standard: 1)"
+        print_info "Välj snapshot-version (standard: 1)" >&2
         local i=1
         for tag in "${tags[@]}"; do
-            printf "  %2d) %s\n" "$i" "$tag"
+            printf "  %2d) %s\n" "$i" "$tag" >&2
             i=$((i + 1))
             if [[ $i -gt 15 ]]; then
                 break
@@ -220,7 +220,7 @@ choose_snapshot_tag() {
             echo "${tags[$((choice - 1))]}"
             return 0
         fi
-        print_warning "Ogiltigt val. Använder senaste snapshot i listan."
+        print_warning "Ogiltigt val. Använder senaste snapshot i listan." >&2
     fi
 
     echo "${tags[0]}"


### PR DESCRIPTION
## Summary
- add group name suggestions in the pipeline group filter settings UI
- source suggestions from known groups already loaded in dashboard
- keep free-text behavior so non-existing group names can still be configured

## Verification
- /Users/nicklas/dev/oden/.venv/bin/python -m pytest -q (262 passed)

## Context
This improves the "Grupper (en per rad)" field by helping users pick existing groups while preserving support for future or manually entered groups.