### PR TITLE
fix: bundle mgrs native library in PyInstaller app

### DIFF
--- a/s7_watcher.spec
+++ b/s7_watcher.spec
@@ -2,6 +2,8 @@
 # PyInstaller spec file for Oden macOS app bundle
 # Builds an app with bundled JRE and signal-cli
 
+import glob
+import importlib.util
 import os
 import sys
 
@@ -45,6 +47,7 @@ hiddenimports = [
     'oden.app_state',
     'oden.tray',
     'PIL',
+    'mgrs',
 ]
 
 if sys.platform == 'darwin':
@@ -52,10 +55,19 @@ if sys.platform == 'darwin':
 elif sys.platform == 'win32':
     hiddenimports.extend(['pystray._win32', 'PIL.ImageWin'])
 
+# mgrs loads its native extension via ctypes at runtime — PyInstaller
+# can't detect this statically, so we collect it explicitly.
+_mgrs_binaries = []
+_mgrs_spec = importlib.util.find_spec('mgrs')
+if _mgrs_spec and _mgrs_spec.origin:
+    _site_pkgs = os.path.dirname(os.path.dirname(_mgrs_spec.origin))
+    for _lib in glob.glob(os.path.join(_site_pkgs, 'libmgrs*.so')):
+        _mgrs_binaries.append((_lib, '.'))
+
 a = Analysis(
     ['oden/s7_watcher.py'],
     pathex=[],
-    binaries=[],
+    binaries=_mgrs_binaries,
     datas=datas,
     hiddenimports=hiddenimports,
     hookspath=[],


### PR DESCRIPTION
## Summary

- `mgrs` loads its native C extension (`libmgrs.cpython-*.so`) via `ctypes.CDLL()` at import time in `mgrs/core.py` — PyInstaller can't detect runtime ctypes loads statically, so the `.so` was never included in the bundle
- App crashed immediately on launch with `Failed to load dynlib/dll libmgrs.cpython-312-darwin.so`
- Fixed by auto-detecting and explicitly adding `libmgrs*.so` to `binaries` in the spec, and adding `mgrs` to `hiddenimports`

## Test plan

- [ ] Rebuild the app (`pyinstaller s7_watcher.spec`) and verify `libmgrs.cpython-*.so` appears in `Contents/Frameworks/`
- [ ] Launch `Oden.app` and confirm it reaches the setup wizard instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)