### PR TITLE
fix(gui): improve regex input contrast in dark mode

### DIFF
--- a/oden/templates/web/css/dashboard.css
+++ b/oden/templates/web/css/dashboard.css
@@ -656,13 +656,18 @@ td {
     color: var(--color-text-subtle);
 }
 .pipeline-settings-row select,
-.pipeline-settings-row textarea {
+.pipeline-settings-row textarea,
+.pipeline-settings-row input[type="text"] {
     width: 100%;
     padding: 6px;
     border: 1px solid var(--color-border);
     border-radius: 4px;
     background: var(--color-bg-surface);
     color: #fff;
+}
+.regex-row-inline {
+    display: flex;
+    align-items: center;
 }
 .pipeline-settings-actions {
     display: flex;


### PR DESCRIPTION
## Summary
- apply pipeline input styling to text inputs in the generic_template settings UI
- fix dark mode contrast for regex name and pattern rows
- align inline regex row layout for more consistent rendering

## Testing
- ./.venv/bin/pytest -q tests/test_web_api.py -k "PipelineManagementAPI or test_dashboard_inline_js_not_escaped"