### PR TITLE
feat: align 7S pipeline with format spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 dist/
 build/
 .gemeni/
+.claude/
 
 # Byte-compiled / optimized / DLL files
 *.pyc

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Noteringar:
 - **System Tray** - Starta/stoppa, öppna GUI och avsluta Oden från systemfältet (macOS/Linux/Windows)
 - **Svara på meddelande** - Svaret läggs till i din senaste rapport (inom 30 min)
 - **`++` kommando** - Meddelanden som börjar med `++` läggs till i senaste rapporten *(avstängt per default, aktiveras i config)*
-- **7S RAPPORT** - Specialpipeline för 7S-format med egen parser och rapportmall
+- **7S RAPPORT** - Specialpipeline för 7S-format som skriver specad 7S-utdata med schemaformad frontmatter
 - **Platslänkar** - Google Maps, Apple Maps och OSM-länkar omvandlas automatiskt till geo-koordinater
 - **Anpassningsbara rapportmallar** - Redigera Jinja2-mallar direkt i GUI:ns template-editor
 - **Regex-länkar** - Konfigurera mönster (t.ex. registreringsnummer) som automatiskt blir Obsidian-länkar
@@ -227,10 +227,12 @@ Vid första start visas en setup-wizard som guidar dig genom konfigurationen:
 - **Ignorera grupper** direkt från GUI (klicka "Ignorera")
 - **Whitelist-grupper** direkt från GUI (klicka "Whitelist" – om satt sparas endast dessa grupper)
 - **Pipelines** - Hantera aktiva pipelines, urvalslogik, på/av och körordning
-- **Template-editor** - Redigera rapportmallar med live-förhandsvisning
+- **Template-editor** - Redigera rapportmallar med live-förhandsvisning via pipeline-inställningarna
 - **Stäng av Oden** - Shutdown-knapp i GUI
 
 **Säkerhet:** Som standard lyssnar webbgränssnittet endast på localhost. Ingen autentisering — skyddet bygger på att gränssnittet enbart nås lokalt, så om du ändrar `WEB_HOST`/`web_host` till t.ex. `0.0.0.0` kan det exponeras för andra maskiner i nätverket.
+
+**7S-format:** 7S-inmatning förväntas komma från verktyget `HvSS-Innovation/7s-rapport` och klistras in i Signal. Oden behandlar därför 7S som ett kanoniskt, verktygsgenererat format snarare än fri fritext.
 
 ## Dokumentation
 
@@ -239,6 +241,8 @@ Vid första start visas en setup-wizard som guidar dig genom konfigurationen:
 - [WEB_GUI.md](./docs/WEB_GUI.md) - Web-gränssnitt och API-referens
 - [REPORT_TEMPLATE.md](./docs/REPORT_TEMPLATE.md) - Mallsystem (Jinja2)
 - [PIPELINES.md](./docs/PIPELINES.md) - Pipeline-arkitektur, befintliga pipelines och hur man utvecklar nya
+- [FORMAT_SPEC.md](./docs/FORMAT_SPEC.md) - Normativ 7S-spec för filformat, länkning och koordinatfält
+- [7S_frontmatter.schema.json](./docs/7S_frontmatter.schema.json) - JSON-schema för 7S-frontmatter
 - [PLAN_PIPELINES_MENU.md](./docs/PLAN_PIPELINES_MENU.md) - Implementationsplan för pipeline-administrationsmeny
 - [PLAN_3.0.md](./docs/PLAN_3.0.md) - Overblick över Oden 3.0 och alla implementationsfaser
 - [WINDOWS_NATIVE_PLAN.md](./docs/WINDOWS_NATIVE_PLAN.md) - Native Windows installer: status och implementationsplan

--- a/docs/7S_frontmatter.schema.json
+++ b/docs/7S_frontmatter.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hvss.example/7S_frontmatter.schema.json",
+  "title": "7S-rapport frontmatter",
+  "description": "Schema for the YAML frontmatter of a 7S report Markdown file produced by the central application. Validates the machine-readable properties only; the Markdown body (the seven 7S fields) is specified in FORMAT_SPEC.md §5.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "typ",
+    "tnr",
+    "tidpunkt",
+    "plats",
+    "sagesman"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable unique identifier, unique across the whole vault. Format '7S-NNN' in sample data; any stable string (e.g. UUID) in production.",
+      "examples": [
+        "7S-004",
+        "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+      ]
+    },
+    "typ": {
+      "const": "7S-rapport",
+      "description": "Constant discriminator separating reports from other notes (e.g. entity stubs created later by the plugin)."
+    },
+    "tnr": {
+      "type": "string",
+      "pattern": "^[0-9]{6}(_[0-9]+)?$",
+      "description": "Tidsnummer DDHHMM, optionally with a collision suffix _n. String (may carry leading zeros and underscore). Matches the filename TNR part without the 'TNR' prefix.",
+      "examples": [
+        "140755",
+        "140755_2"
+      ]
+    },
+    "tidpunkt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$",
+      "description": "ISO 8601 local datetime (no timezone offset). The authoritative timestamp of the observation.",
+      "examples": [
+        "2026-02-14T07:55:00"
+      ]
+    },
+    "plats": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Free-text place name. Always quoted in YAML because it may contain special characters.",
+      "examples": [
+        "Grusparkering vid motionsspåret",
+        "Vägren E4 avfart söderut"
+      ]
+    },
+    "lat": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90,
+      "description": "WGS84 latitude in decimal degrees (~5 decimals). Omit entirely if coordinates unknown — do not use null or 0.",
+      "examples": [
+        59.26608
+      ]
+    },
+    "lon": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180,
+      "description": "WGS84 longitude in decimal degrees (~5 decimals). Omit entirely if coordinates unknown.",
+      "examples": [
+        17.70644
+      ]
+    },
+    "sagesman": {
+      "type": "string",
+      "pattern": "^[A-E]Q$",
+      "description": "Reporting unit call sign. Company QO; line platoons AQ/BQ/CQ/DQ, staff platoon EQ. (Production may use finer signs; widen this pattern then.)",
+      "examples": [
+        "AQ",
+        "CQ",
+        "EQ"
+      ]
+    },
+    "location": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^-?[0-9]+(\\.[0-9]+)?,-?[0-9]+(\\.[0-9]+)?$",
+          "description": "Map View text format 'lat,lon'."
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2,
+          "description": "Map View list format [lat, lon]."
+        }
+      ],
+      "description": "Combined coordinate for the Obsidian Map View plugin (FORMAT_SPEC.md §8). REQUIRED when lat/lon are present and must mirror them exactly; omit only when coordinates are unknown. String form 'lat,lon' is used in this format; the [lat, lon] list form is also accepted by Map View."
+    }
+  },
+  "dependentRequired": {
+    "lat": [
+      "lon",
+      "location"
+    ],
+    "lon": [
+      "lat",
+      "location"
+    ]
+  },
+  "allOf": [
+    {
+      "$comment": "When coordinates are present, 'location' must be the string form 'lat,lon'. (Exact equality with lat/lon is enforced by the application, not expressible in JSON Schema.)",
+      "if": {
+        "required": [
+          "lat",
+          "lon"
+        ]
+      },
+      "then": {
+        "properties": {
+          "location": {
+            "type": "string",
+            "pattern": "^-?[0-9]+(\\.[0-9]+)?,-?[0-9]+(\\.[0-9]+)?$"
+          }
+        },
+        "required": [
+          "location"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,6 +9,8 @@ Oden tar emot Signal-meddelanden via `signal-cli` och sparar dem som Markdown-fi
 | [SETUP_FLOW.md](SETUP_FLOW.md) | Setup-wizardens alla steg (hemkatalog, Signal-länkning, vault-sökväg) |
 | [WEB_GUI.md](WEB_GUI.md) | Web-gränssnittets alla sidor, flikar och komplett API-endpointstabell |
 | [REPORT_TEMPLATE.md](REPORT_TEMPLATE.md) | Jinja2-mallsystem — placeholders, syntax och anpassning |
+| [FORMAT_SPEC.md](FORMAT_SPEC.md) | Normativ specifikation för Oden 7S-utdata |
+| [7S_frontmatter.schema.json](7S_frontmatter.schema.json) | JSON-schema för 7S-frontmatter |
 
 ---
 
@@ -42,7 +44,7 @@ Oden tar emot Signal-meddelanden via `signal-cli` och sparar dem som Markdown-fi
 - **`config.py` / `config_db.py`** — Konfiguration via SQLite-databas (`config.db`). Exponerar konstanter som `VAULT_PATH`, `SIGNAL_NUMBER`, `TIMEZONE` och DB-first/pipeline-inställningar.
 - **`app_state.py`** — Singleton med delat tillstånd. Central JSON-RPC-dispatcher: `send_jsonrpc()` registrerar Futures per request-id, `dispatch_line()` dirigerar svar och notifikationer.
 - **`signal_listener.py` / `pipeline_orchestrator.py`** — DB-first ingest: råmeddelanden sparas först i SQLite, därefter körs aktiva pipelines i ordning.
-- **`pipelines/`** — `generic_template.py` kapslar in nuvarande generiska beteende och `seven_s.py` hanterar 7S RAPPORT som specialfall.
+- **`pipelines/`** — `generic_template` kapslar in nuvarande generiska beteende och `seven_s.py` hanterar 7S RAPPORT som specialfall enligt separat format-spec.
 - **`messages_db.py` / `pipelines_db.py`** — Lagrar råmeddelanden, pipeline-runs och pipeline-events för revision och reprocess.
 - **`web_server.py` / `web_handlers/`** — aiohttp-baserat webbgränssnitt med setup-wizard och dashboard. Kontohantering via `account_handlers.py`.
 - **`template_loader.py`** — Jinja2-mallmotor med LRU-cache och sandboxed rendering.
@@ -135,6 +137,8 @@ Från och med Oden 3.0 lagras varje inkommande envelope först i SQLite som ett 
 #### Pipeline-ordning
 
 1. `SevenSPipeline` försöker matcha och validera 7S RAPPORT-format.
+  7S-inmatning förväntas komma från `HvSS-Innovation/7s-rapport` och därefter klistras in i Signal.
+  Pipeline-utdata följer [FORMAT_SPEC.md](FORMAT_SPEC.md) och frontmatter ska stämma med [7S_frontmatter.schema.json](7S_frontmatter.schema.json).
 2. Om meddelandet inte matchar eller om 7S-pipelinen är avstängd går det vidare till `GenericTemplatePipeline`.
 3. Varje körning loggas i `pipeline_runs` och detaljerade steg loggas i `pipeline_events`.
 4. Reprocess kan köras från Web GUI på en enskild meddelanderad.

--- a/docs/FORMAT_SPEC.md
+++ b/docs/FORMAT_SPEC.md
@@ -1,0 +1,304 @@
+# 7S-meddelandeformat — specifikation för den centrala applikationen
+
+**Version:** 1.0
+**Datum:** 2026-06-24
+**Mottagare:** utvecklare av den centrala applikationen (Signal → formaterat 7S)
+
+---
+
+## 1. Syfte och avgränsning
+
+Den centrala applikationen tar emot fritext-observationer (via Signal),
+strukturerar dem enligt Försvarsmaktens 7S-mall och skriver ut en
+Markdown-fil per meddelande till en delad mapp (en Obsidian-vault).
+
+Detta dokument specificerar **utdataformatet** — exakt hur varje fil ska se ut.
+Det specificerar **inte** hur tolkningen/extraktionen går till internt.
+
+**Viktig avgränsning — vad applikationen INTE ska göra:**
+Applikationen utför *enkel, regelbaserad* länkning av kännetecken (se §6). Den
+ska **inte** göra analys: ingen återidentifiering (avgöra att två partiella
+nummerplåtar är samma fordon), ingen klustring, inga aggregerade entitetsnoter,
+ingen mönsterdetektering. Sådant sker i ett separat analyssteg (en
+Obsidian-plugin) som läser dessa filer. Applikationens uppgift är att producera
+*rena, korrekt länkade meddelanden* — varken mer eller mindre.
+
+---
+
+## 2. Filnamn
+
+```
+TNR<DDHHMM>[_<n>].md
+```
+
+- `TNR` — fast prefix (versaler).
+- `DDHHMM` — tidsnummer ur observationens tidpunkt: dag-i-månad, timme, minut,
+  nollutfyllt tvåsiffrigt (UTC-offset enligt §4). Ex: 14 feb 07:55 → `140755`.
+- `_<n>` — kollisionssuffix. Om en fil med samma TNR redan finns läggs `_2`,
+  `_3`, … till i ankomstordning. Första filen får inget suffix.
+- Exempel: `TNR140755.md`, `TNR140755_2.md`.
+
+> Notera: DDHHMM saknar månad/år. Inom en avgränsad insats (dagar–veckor) är det
+> tillräckligt unikt; kollisioner hanteras med suffix. Fullständig tidpunkt
+> finns alltid i frontmatter (§4).
+
+---
+
+## 3. Filstruktur (övergripande)
+
+Varje fil består av två delar:
+
+1. **YAML-frontmatter** mellan `---`-rader (maskinläsbara egenskaper, §4).
+2. **Rapportkropp** i Markdown (människoläsbar 7S-text, §5).
+
+En tom rad skiljer frontmatter från kropp. Filen är UTF-8, LF-radslut, och
+avslutas med en avslutande nyrad.
+
+---
+
+## 4. Frontmatter (YAML)
+
+Exakt dessa nycklar, i denna ordning:
+
+```yaml
+---
+id: 7S-004
+typ: 7S-rapport
+tnr: "140755"
+tidpunkt: "2026-02-14T07:55:00"
+plats: "Grusparkering vid motionsspåret"
+lat: 59.26608
+lon: 17.70644
+location: "59.26608,17.70644"
+sagesman: AQ
+---
+```
+
+| Nyckel      | Typ      | Regler |
+|-------------|----------|--------|
+| `id`        | sträng   | Stabil unik identifierare. Format `7S-NNN` i exempeldata; valfri stabil sträng i drift (t.ex. UUID). Måste vara unik över hela vaulten. |
+| `typ`       | sträng   | Konstant `7S-rapport`. Skiljer rapporter från andra noter i grafvyn. |
+| `tnr`       | sträng   | Samma som filnamnets TNR-del, **utan** `TNR`-prefix och **utan** `.md`. Inkludera ev. kollisionssuffix (`140755_2`). Sträng, inte tal (kan ha ledande nollor och `_`). |
+| `tidpunkt`  | sträng   | ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Observationens tidpunkt. Detta är den auktoritativa tidsstämpeln. |
+| `plats`     | sträng   | Fritext-platsnamn. **Citerad** (dubbelfnuttar) eftersom den kan innehålla specialtecken. |
+| `lat`       | tal      | WGS84 decimalgrader, 5 decimaler. Nordlig latitud positiv. |
+| `lon`       | tal      | WGS84 decimalgrader, 5 decimaler. Östlig longitud positiv. |
+| `location`  | sträng   | Kombinerad koordinat `"lat,lon"` för kartvy (§8). **Krävs när koordinater finns** och måste spegla `lat`/`lon` exakt. Utelämnas helt om koordinater saknas. |
+| `sagesman`  | sträng   | Anropssignal för rapporterande enhet (§7). |
+
+Regler:
+- Saknas koordinater för en observation: utelämna `lat`, `lon` **och**
+  `location` helt (skriv dem inte som `null` eller `0`). `plats` bör ändå anges
+  som fritext.
+- Lägg inte till extra nycklar utan att uppdatera denna spec och schemat.
+- Kombinerad koordinat för kartvy: se §8 (`location`-nyckel, krav när koordinater finns).
+
+---
+
+## 5. Rapportkropp (7S)
+
+Exakt dessa sju fält, i denna ordning, var och en med **fet** etikett följd av
+kolon, och åtskilda av en tom rad. TNR upprepas först i kroppen för läsbarhet.
+
+```markdown
+**TNR:** 140755
+
+**Stund:** 2026-02-14 07:55
+
+**Ställe:** Grusparkering vid motionsspåret
+
+**Styrka:** 2 personer
+
+**Slag:** Person
+
+**Sysselsättning:** Fiskade vid vattnet.
+
+**Sagesman:** AQ
+```
+
+Fälten (7S):
+
+| Fält              | Innehåll |
+|-------------------|----------|
+| `TNR`             | = frontmatter `tnr`. |
+| `Stund`           | Tidpunkt, människoläsbar `YYYY-MM-DD HH:MM` (utan sekunder). Samma ögonblick som `tidpunkt`. |
+| `Ställe`          | = frontmatter `plats` (utan citationstecken). |
+| `Styrka`          | Antal/styrka. Ex: `1 fordon`, `2 personer`, `1 fordon, 2 personer`, `Familj (3-4)`. |
+| `Slag`            | Typ av observation. Ex: `Person`, `Fordon`, `Fordon + person`, `Person (cykel)`, `Fordon (jordbruk)`. |
+| `Sysselsättning`  | Vad de gör. Fritext, en mening. |
+| `Symbol`          | Särskiljande kännetecken. **Här placeras länkar** (§6). |
+| `Sagesman`        | = frontmatter `sagesman`. |
+
+**Konsistenskrav:** fälten måste vara inbördes förenliga. Ett `Slag: Fordon`
+får inte ha `Sysselsättning` eller `Symbol` som beskriver en fotgängare, och
+vice versa. (Detta gäller den centrala applikationens *tolkning* av fritexten.)
+
+---
+
+## 6. Länkning av kännetecken (Obsidian-wikilänkar)
+
+Den centrala applikationen identifierar särskiljande kännetecken i fält
+**Symbol** med enkel, regelbaserad matchning och omsluter dem med `[[ ]]`
+(Obsidian-wikilänkssyntax). Detta skapar noder i Obsidians graf.
+
+### 6.1 Vad som ska länkas
+
+| Kategori | Regel | Exempel i text |
+|----------|-------|----------------|
+| Fullständig nummerplåt | Svenskt format (§6.3) | `reg [[RJK241]]` |
+| Partiell nummerplåt | Plåt där tecken saknas; maskera saknade positioner med `.` (§6.4) | `reg [[..G41.]]` |
+| Annat distinkt kännetecken som matchas regelbundet | Kanoniserad etikett (§6.5) | `[[logotyp-fragment DGE]]` |
+
+### 6.2 Vad som INTE ska länkas
+
+- Generiska beskrivningar utan särskiljande värde (`vardaglig klädsel`,
+  `man ca 40 år`).
+- Fordonsmärke/-modell/-färg ensamt (`mörkröd Toyota Avensis`) — det är
+  kontext, inte en identifierare. (Endast plåten länkas.)
+- Tolkningar/slutsatser. Länka det som *observerats*, inte det som *antas*.
+
+### 6.3 Svenskt nummerplåtsformat (fullständig)
+
+Två giltiga mönster:
+- `AAA NNN` — tre bokstäver, tre siffror.
+- `AAA NNL` — tre bokstäver, två siffror, en bokstav.
+
+I länken skrivs plåten **utan mellanslag**: `RJK241`, `WBN84X`.
+
+Tillåtna bokstäver: `A-Z` utom `I O Q V` (svensk konvention, undviker
+förväxling). Använd versaler.
+
+Regex (fullständig plåt):
+```
+^[ABCDEFGHJKLMNPRSTUWXYZ]{3}[0-9]{2}[0-9ABCDEFGHJKLMNPRSTUWXYZ]$
+```
+
+### 6.4 Partiell nummerplåt
+
+När observatören bara sett delar av plåten: behåll plåtens **längd och
+struktur**, ersätt varje **oläst position** med en punkt `.`. Punkten fungerar
+som en regex-wildcard mot den fullständiga plåten.
+
+- `RJK241` delvis sedd → t.ex. `..G41.`? **Nej** — positionerna måste stämma.
+  Om position 4–5 lästes som `24` och resten är oläst: `...24.`.
+- Maskera *faktiska* olästa positioner; gissa inte tecken.
+- Behåll total längd (6 tecken).
+
+Regex (partiell plåt — minst en punkt, i övrigt giltig struktur):
+```
+^[A-Z.]{3}[0-9.]{2}[0-9A-Z.]$   (och innehåller minst ett '.')
+```
+
+> En partiell plåt ska kunna matchas mot en fullständig med
+> `re.match('^' + partiell + '$', fullständig)` (punkt = wildcard). Att *avgöra*
+> vilken fullständig plåt den motsvarar är **analys (plugin)**, inte
+> applikationens uppgift.
+
+### 6.5 Kanoniserade kännetecken-etiketter
+
+För icke-plåt-kännetecken som matchas regelbundet (logotyp-fragment,
+ryggsäcksmärkning, keps m.m.): använd en **stabil, kanonisk etikett** så att
+samma kännetecken alltid ger samma länktext (och därmed samma nod). Etiketten
+är kort beskrivande svenska, gemener.
+
+Exempel som används i testdata:
+- `[[logotyp-fragment DGE]]`
+- `[[ryggsäck märkning delvis läsbar -TAC]]`
+- `[[keps mörk med ljust emblem]]`
+
+Kravet är **determinism**: identiskt observerat kännetecken → identisk
+länktext. Variation i fritext ska normaliseras till den kanoniska etiketten
+innan länkning.
+
+### 6.6 Inga entitetsfiler
+
+Applikationen skapar **endast länkarna i meddelandet**. Den skapar **inga**
+not-filer för entiteterna. En länk till en fil som inte finns blir en
+"unresolved link"-nod i Obsidian — det är avsett. Att skapa och berika
+entitetsnoter är analyssteget (plugin).
+
+---
+
+## 7. Anropssignaler (`sagesman`)
+
+Kompani med huvudanropssignal **QO**. Plutoner:
+
+| Signal | Pluton |
+|--------|--------|
+| `AQ`   | 1. skyttepluton (linje) |
+| `BQ`   | 2. skyttepluton (linje) |
+| `CQ`   | 3. skyttepluton (linje) |
+| `DQ`   | 4. skyttepluton (linje) |
+| `EQ`   | stabspluton |
+
+I drift kan finare signaler förekomma; för detta format räcker plutonsnivå.
+Geografisk koppling (en pluton ansvarar normalt för en sektor) är en
+*egenskap hos insatsen*, inte ett formatkrav.
+
+---
+
+## 8. Kart-kompatibel koordinat (`location`) — KRAV
+
+Obsidians kartvy (community-plugin "Map View") läser **inte** separata
+`lat`/`lon`-nycklar automatiskt. Därför **krävs** en kombinerad nyckel i
+frontmatter när koordinater finns:
+
+```yaml
+location: "59.26608,17.70644"
+```
+
+- Format: sträng `"lat,lon"` (Map Views textformat). Decimalpunkt, komma som
+  separator, inget mellanslag. Värdena ska vara **identiska** med `lat`/`lon`.
+- `lat`/`lon` behålls som maskinläsbara tal (för t.ex. avståndsberäkning i
+  analyssteget); `location` är den kartläsbara dubbletten.
+- Saknas koordinater: utelämna alla tre (`lat`, `lon`, `location`).
+
+> Listformatet `[lat, lon]` accepteras också av Map View, men för enhetlighet
+> i detta format används strängformen `"lat,lon"`.
+
+---
+
+## 9. Teckenkodning och robusthet
+
+- UTF-8 utan BOM. Svenska tecken (å ä ö) skrivs som sig själva, inte escapade.
+- LF radslut.
+- Citera `plats` (och varje frontmatter-strängvärde som kan innehålla `:`,
+  `#`, `[`, citationstecken eller inledande/avslutande blanksteg).
+- **Citera `tnr` och `tidpunkt`** (dubbelfnuttar) så att YAML-parsers behandlar
+  dem som strängar — annars tolkas `tidpunkt` som en YAML-timestamp och `tnr`
+  som ett heltal, vilket bryter schemavalidering.
+- Validera mot JSON-schemat (`7S_frontmatter.schema.json`) innan skrivning.
+
+---
+
+## 10. Minimiexempel (komplett fil)
+
+```markdown
+---
+id: 7S-004
+typ: 7S-rapport
+tnr: "140755"
+tidpunkt: "2026-02-14T07:55:00"
+plats: "Vägren E4 avfart söderut"
+lat: 59.25401
+lon: 17.69812
+sagesman: CQ
+location: "59.25401,17.69812"
+---
+
+**TNR:** 140755
+
+**Stund:** 2026-02-14 07:55
+
+**Ställe:** Vägren E4 avfart söderut
+
+**Styrka:** 1 fordon, 1 person
+
+**Slag:** Fordon + person
+
+**Sysselsättning:** Långsam passage, andra varvet inom 25 min.
+
+**Symbol:** mörkröd Toyota Avensis, reg [[..G41.]]. Två män, medelålders. Delvis synlig [[logotyp-fragment DGE]] på bakrutan.
+
+**Sagesman:** CQ
+```

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -45,36 +45,64 @@ Nuvarande default:
 
 **Vad den väljer:** Meddelanden som börjar med `7S RAPPORT` (skiftlägesokänsligt).
 
+**Förväntad indata:** 7S-rapporter skapas av `HvSS-Innovation/7s-rapport` och kopieras därefter in i Signal. Pipelinen är därför optimerad för ett kanoniskt, verktygsgenererat 7S-format.
+
 **Vad den gör:**
 - Parsar strukturerad 7S-rapport (Till, Från, TNR, Stund, Ställe, Styrka, Slag, Sysselsättning, Symbol, Sagesman, Sedan)
-- Validerar alla obligatoriska fält
-- Skriver strukturerad markdown-fil till `vault/{group_name}/` med specifik namngivning
-- Kontaktnamnuppslagning via signal-cli
+- Validerar alla obligatoriska fält och schemakritiska värden som `TNR`, `Stund` och `Sagesman`
+- Skriver strukturerad markdown-fil till `vault/{group_name}/TNR<DDHHMM>[_n].md`
+- Genererar schemaformad YAML-frontmatter enligt [FORMAT_SPEC.md](FORMAT_SPEC.md) och [7S_frontmatter.schema.json](7S_frontmatter.schema.json)
+- Konverterar MGRS i `Ställe` till `lat`, `lon` och `location` när koordinater kan härledas
+- Länkar särskiljande kännetecken i `Symbol` med `[[...]]` enligt specen
 
 **Exempel på inmatning:**
 ```
 7S RAPPORT
-Till: NAMN EFTERNAMN
-Från: NAMN EFTERNAMN
-TNR: 220932
-Stund: 220930
-Ställe: 33VXF 56007 96107
-Styrka: 2
-Slag: Personbil
-Sysselsättning: Spanar
-Symbol: Svart
-Sagesman: 2A GRUPP
-Sedan: Fortsätter spaning
+Till: TST
+Från: TS
+TNR: 221520
+Stund: 221520
+Ställe: 34VCM 79349 26095, Långkärrsvägen
+Styrka: 1
+Slag: Vi
+Sysselsättning: Patrull
+Symbol: ABC123 och logotyp-fragment DGE
+Sagesman: AQ
+Sedan: Återgår till bas
 ```
 
 **Output-struktur:**
 ```
-# 7S RAPPORT — [Till]
-Från: [Namn]
-TNR: [Nummer]
-Stund: [Tidstämpel]
-...
+---
+id: 7S-...
+typ: 7S-rapport
+tnr: "221520"
+tidpunkt: "2026-06-22T15:20:00"
+plats: "Långkärrsvägen"
+lat: 59.49063
+lon: 17.46740
+location: "59.49063,17.46740"
+sagesman: AQ
+---
+
+**TNR:** 221520
+
+**Stund:** 2026-06-22 15:20
+
+**Ställe:** Långkärrsvägen
+
+**Styrka:** 1
+
+**Slag:** Vi
+
+**Sysselsättning:** Patrull
+
+**Symbol:** [[ABC123]] och [[logotyp-fragment DGE]]
+
+**Sagesman:** AQ
 ```
+
+Full normativ specifikation finns i [FORMAT_SPEC.md](FORMAT_SPEC.md).
 
 **Status i DB:** Om meddelande är en 7S RAPPORT markeras det som *processed* efter första körningen.
 

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -137,7 +137,6 @@ def _link_remaining_plates(text: str) -> str:
     return "".join(linked_segments)
 
 
-
 def _build_7s_filepath(group_title: str, tnr_base: str) -> tuple[str, str]:
     group_dir = get_safe_group_dir_path(group_title)
     os.makedirs(group_dir, exist_ok=True)

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -56,7 +56,7 @@ _LABEL_ALIASES = {
 
 _PLATE_ALPHABET = "ABCDEFGHJKLMNPRSTUWXYZ"
 _FULL_PLATE_RE = re.compile(rf"\b([{_PLATE_ALPHABET}]{{3}}[0-9]{{2}}[0-9{_PLATE_ALPHABET}])\b", re.IGNORECASE)
-_PARTIAL_PLATE_RE = re.compile(r"\b([A-Z.]{3}[0-9.]{2}[0-9A-Z.])\b", re.IGNORECASE)
+_PARTIAL_PLATE_RE = re.compile(r"\b(?=[A-Z0-9.]*\.)([A-Z.]{3}[0-9.]{2}[0-9A-Z.])\b", re.IGNORECASE)
 
 
 def _normalize_label(label: str) -> str:
@@ -122,10 +122,7 @@ def _link_remaining_plates(text: str) -> str:
         return f"[[{match.group(1).upper()}]]"
 
     def wrap_partial(match: re.Match[str]) -> str:
-        plate = match.group(1).upper()
-        if "." not in plate:
-            return plate
-        return f"[[{plate}]]"
+        return f"[[{match.group(1).upper()}]]"
 
     linked_segments: list[str] = []
     for segment in re.split(r"(\[\[[^\]]+\]\])", text):
@@ -139,10 +136,6 @@ def _link_remaining_plates(text: str) -> str:
 
     return "".join(linked_segments)
 
-
-def _link_symbol_text(text: str) -> str:
-    linked = apply_regex_links(text) or text
-    return _link_remaining_plates(linked)
 
 
 def _build_7s_filepath(group_title: str, tnr_base: str) -> tuple[str, str]:
@@ -262,7 +255,8 @@ class SevenSPipeline:
         plats, lat, lon = _extract_location(fields["stalle"])
         tidpunkt = observation_dt.strftime("%Y-%m-%dT%H:%M:%S")
         stund_display = observation_dt.strftime("%Y-%m-%d %H:%M")
-        symbol = _link_symbol_text(fields["symbol"].strip())
+        symbol_raw = fields["symbol"].strip()
+        symbol = _link_remaining_plates(apply_regex_links(symbol_raw) or symbol_raw)
 
         frontmatter_lines = [
             "---",

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -7,17 +7,20 @@ entry. Non-matching messages are skipped so downstream pipelines can process.
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import os
 import re
 import unicodedata
+import uuid
 from typing import Any
 
 import mgrs
 
 from oden import config as cfg
 from oden.app_state import get_app_state
-from oden.formatting import format_sender_display, get_message_filepath
+from oden.formatting import get_safe_group_dir_path
+from oden.link_formatter import apply_regex_links
 
 _REQUIRED_FIELDS = {
     "till",
@@ -51,6 +54,10 @@ _LABEL_ALIASES = {
     "sedan": "sedan",
 }
 
+_PLATE_ALPHABET = "ABCDEFGHJKLMNPRSTUWXYZ"
+_FULL_PLATE_RE = re.compile(rf"\b([{_PLATE_ALPHABET}]{{3}}[0-9]{{2}}[0-9{_PLATE_ALPHABET}])\b", re.IGNORECASE)
+_PARTIAL_PLATE_RE = re.compile(r"\b([A-Z.]{3}[0-9.]{2}[0-9A-Z.])\b", re.IGNORECASE)
+
 
 def _normalize_label(label: str) -> str:
     text = unicodedata.normalize("NFKD", label).encode("ascii", "ignore").decode("ascii")
@@ -59,29 +66,98 @@ def _normalize_label(label: str) -> str:
     return _LABEL_ALIASES.get(text, text)
 
 
-def _extract_location(stalle: str) -> tuple[str, str | None]:
-    """Extract location (address) and coordinates from Ställe field.
+def _yaml_quote(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
 
-    Handles MGRS format: "34VCM 79349 26095, Långkärrsvägen"
-    Returns: (address, "[lat, lon]" for Obsidian Maps or None if conversion fails)
-    """
+
+def _extract_location(stalle: str) -> tuple[str, float | None, float | None]:
+    """Extract place text and optional decimal coordinates from Ställe."""
     if "," not in stalle:
-        return stalle.strip(), None
+        return stalle.strip(), None, None
 
     parts = stalle.split(",", 1)
     mgrs_str = parts[0].strip()
     address = parts[1].strip() if len(parts) > 1 else ""
 
-    # Try to convert MGRS to decimal coordinates for Obsidian Maps plugin
-    coords = None
+    lat = None
+    lon = None
     try:
         m = mgrs.MGRS()
         lat, lon = m.toLatLon(mgrs_str)
-        coords = f"[{lat:.6f}, {lon:.6f}]"
     except Exception as e:
         logging.getLogger(__name__).debug(f"Failed to convert MGRS '{mgrs_str}' to coordinates: {e}")
 
-    return address or stalle.strip(), coords
+    return address or stalle.strip(), lat, lon
+
+
+def _resolve_observation_datetime(stund: str, reference_dt: datetime.datetime) -> datetime.datetime:
+    if not re.fullmatch(r"\d{6}", stund):
+        raise ValueError("7S Stund must be DDHHMM")
+
+    day = int(stund[0:2])
+    hour = int(stund[2:4])
+    minute = int(stund[4:6])
+
+    try:
+        candidate = reference_dt.replace(day=day, hour=hour, minute=minute, second=0, microsecond=0)
+    except ValueError as exc:
+        raise ValueError("7S Stund is not a valid local date/time") from exc
+
+    if candidate > reference_dt:
+        year = reference_dt.year
+        month = reference_dt.month - 1
+        if month == 0:
+            month = 12
+            year -= 1
+        try:
+            candidate = candidate.replace(year=year, month=month)
+        except ValueError as exc:
+            raise ValueError("7S Stund is not a valid local date/time") from exc
+
+    return candidate
+
+
+def _link_remaining_plates(text: str) -> str:
+    def wrap_full(match: re.Match[str]) -> str:
+        return f"[[{match.group(1).upper()}]]"
+
+    def wrap_partial(match: re.Match[str]) -> str:
+        plate = match.group(1).upper()
+        if "." not in plate:
+            return plate
+        return f"[[{plate}]]"
+
+    linked_segments: list[str] = []
+    for segment in re.split(r"(\[\[[^\]]+\]\])", text):
+        if not segment or segment.startswith("[["):
+            linked_segments.append(segment)
+            continue
+
+        segment = _FULL_PLATE_RE.sub(wrap_full, segment)
+        segment = _PARTIAL_PLATE_RE.sub(wrap_partial, segment)
+        linked_segments.append(segment)
+
+    return "".join(linked_segments)
+
+
+def _link_symbol_text(text: str) -> str:
+    linked = apply_regex_links(text) or text
+    return _link_remaining_plates(linked)
+
+
+def _build_7s_filepath(group_title: str, tnr_base: str) -> tuple[str, str]:
+    group_dir = get_safe_group_dir_path(group_title)
+    os.makedirs(group_dir, exist_ok=True)
+
+    tnr = tnr_base
+    counter = 2
+    while True:
+        filename = f"TNR{tnr}.md"
+        filepath = os.path.join(group_dir, filename)
+        if not os.path.exists(filepath):
+            return filepath, tnr
+        tnr = f"{tnr_base}_{counter}"
+        counter += 1
 
 
 def is_7s_message(message_text: str | None) -> bool:
@@ -166,43 +242,68 @@ class SevenSPipeline:
             else datetime.datetime.now(cfg.TIMEZONE)
         )
 
+        raw_tnr = fields["tnr"].strip()
+        raw_stund = fields["stund"].strip()
+        if not re.fullmatch(r"\d{6}", raw_tnr):
+            raise ValueError("7S TNR must be DDHHMM")
+        if raw_tnr != raw_stund:
+            raise ValueError("7S TNR and Stund must match")
+
+        sagesman = fields["sagesman"].strip().upper()
+        if not re.fullmatch(r"[A-E]Q", sagesman):
+            raise ValueError("7S Sagesman must match schema pattern [A-E]Q")
+
+        observation_dt = _resolve_observation_datetime(raw_stund, dt)
+        resolved_tnr = observation_dt.strftime("%d%H%M")
+
         resolved_group_title = group_title or "inbox"
-        filepath = get_message_filepath(resolved_group_title, dt, source_name, source_number)
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        filepath, resolved_tnr = _build_7s_filepath(resolved_group_title, resolved_tnr)
 
-        sender_display = format_sender_display(source_name, source_number)
-        timestamp_iso = dt.isoformat()
-        address, coords = _extract_location(fields["stalle"])
+        plats, lat, lon = _extract_location(fields["stalle"])
+        tidpunkt = observation_dt.strftime("%Y-%m-%dT%H:%M:%S")
+        stund_display = observation_dt.strftime("%Y-%m-%d %H:%M")
+        symbol = _link_symbol_text(fields["symbol"].strip())
 
-        frontmatter = (
-            "---\n"
-            "report_type: 7s\n"
-            f"group_title: {resolved_group_title}\n"
-            f"group_id: {group_id or ''}\n"
-            f"timestamp: {timestamp_iso}\n"
-        )
-        if coords:
-            frontmatter += f"location: {coords}\n"
-        frontmatter += "---\n\n"
+        frontmatter_lines = [
+            "---",
+            f"id: 7S-{uuid.uuid4()}",
+            "typ: 7S-rapport",
+            f"tnr: {_yaml_quote(resolved_tnr)}",
+            f"tidpunkt: {_yaml_quote(tidpunkt)}",
+            f"plats: {_yaml_quote(plats)}",
+        ]
+        if lat is not None and lon is not None:
+            lat_str = f"{lat:.5f}"
+            lon_str = f"{lon:.5f}"
+            frontmatter_lines.extend(
+                [
+                    f"lat: {lat_str}",
+                    f"lon: {lon_str}",
+                    f"location: {_yaml_quote(f'{lat_str},{lon_str}')}",
+                ]
+            )
+        frontmatter_lines.extend([f"sagesman: {sagesman}", "---", ""])
 
-        content = (
-            frontmatter
-            + "# 7S RAPPORT\n\n"
-            + f"- Till: {fields['till']}\n"
-            + f"- Från: {fields['fran']}\n"
-            + f"- TNR: {fields['tnr']}\n"
-            + f"- Stund: {fields['stund']}\n"
-            + f"- Ställe: {fields['stalle']}\n"
-            + f"- Styrka: {fields['styrka']}\n"
-            + f"- Slag: {fields['slag']}\n"
-            + f"- Sysselsättning: {fields['sysselsattning']}\n"
-            + f"- Symbol: {fields['symbol']}\n"
-            + f"- Sagesman: {fields['sagesman']}\n"
-            + f"- Sedan: {fields['sedan']}\n\n"
-            + "## Metadata\n\n"
-            + f"- Avsändare: {sender_display}\n"
-            + f"- Inkom: {timestamp_iso}\n"
-        )
+        body_lines = [
+            f"**TNR:** {resolved_tnr}",
+            "",
+            f"**Stund:** {stund_display}",
+            "",
+            f"**Ställe:** {plats}",
+            "",
+            f"**Styrka:** {fields['styrka'].strip()}",
+            "",
+            f"**Slag:** {fields['slag'].strip()}",
+            "",
+            f"**Sysselsättning:** {fields['sysselsattning'].strip()}",
+            "",
+            f"**Symbol:** {symbol}",
+            "",
+            f"**Sagesman:** {sagesman}",
+            "",
+        ]
+
+        content = "\n".join(frontmatter_lines + body_lines)
 
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -91,20 +91,20 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(output_path.exists())
             content = output_path.read_text(encoding="utf-8")
 
-        self.assertIn('typ: 7S-rapport', content)
+        self.assertIn("typ: 7S-rapport", content)
         self.assertIn('tnr: "221520"', content)
         self.assertIn('tidpunkt: "2026-06-22T15:20:00"', content)
         self.assertIn('plats: "Långkärrsvägen"', content)
-        self.assertIn('lat: 59.49063', content)
-        self.assertIn('lon: 17.46740', content)
+        self.assertIn("lat: 59.49063", content)
+        self.assertIn("lon: 17.46740", content)
         self.assertIn('location: "59.49063,17.46740"', content)
-        self.assertIn('sagesman: AQ', content)
-        self.assertIn('**TNR:** 221520', content)
-        self.assertIn('**Stund:** 2026-06-22 15:20', content)
-        self.assertIn('**Ställe:** Långkärrsvägen', content)
-        self.assertIn('**Symbol:** [[ABC123]] och [[logotyp-fragment DGE]]', content)
-        self.assertNotIn('# 7S RAPPORT', content)
-        self.assertNotIn('## Metadata', content)
+        self.assertIn("sagesman: AQ", content)
+        self.assertIn("**TNR:** 221520", content)
+        self.assertIn("**Stund:** 2026-06-22 15:20", content)
+        self.assertIn("**Ställe:** Långkärrsvägen", content)
+        self.assertIn("**Symbol:** [[ABC123]] och [[logotyp-fragment DGE]]", content)
+        self.assertNotIn("# 7S RAPPORT", content)
+        self.assertNotIn("## Metadata", content)
 
     @patch("oden.pipelines.seven_s.get_app_state")
     async def test_run_adds_collision_suffix_to_filename_and_tnr(self, mock_get_app_state):
@@ -130,7 +130,7 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
             content = output_path.read_text(encoding="utf-8")
 
         self.assertIn('tnr: "221520_2"', content)
-        self.assertIn('**TNR:** 221520_2', content)
+        self.assertIn("**TNR:** 221520_2", content)
 
     async def test_run_skips_non_7s(self):
         pipeline = SevenSPipeline()

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -7,6 +7,26 @@ from unittest.mock import AsyncMock, Mock, patch
 from oden import config as cfg
 from oden.pipelines.seven_s import SevenSPipeline, is_7s_message, parse_7s_report
 
+_TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
+
+
+def _make_msg_data(*, sagesman="AQ", stalle="Långkärrsvägen", symbol="Svart", group="7s-test"):
+    return {
+        "envelope": {
+            "sourceName": "Nicklas",
+            "sourceNumber": "+46701234567",
+            "timestamp": _TIMESTAMP,
+            "dataMessage": {
+                "message": (
+                    f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: 221520\nStund: 221520\n"
+                    f"Ställe: {stalle}\nStyrka: 1\nSlag: Vi\nSysselsättning: Patrull\n"
+                    f"Symbol: {symbol}\nSagesman: {sagesman}\nSedan: Återgår till bas\n"
+                ),
+                "groupV2": {"name": group, "id": "group123"},
+            },
+        }
+    }
+
 
 class TestSevenSPipelineHelpers(unittest.TestCase):
     def test_is_7s_message_true(self):
@@ -55,31 +75,10 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
             pipeline = SevenSPipeline()
-            timestamp = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
-            msg_data = {
-                "envelope": {
-                    "sourceName": "Nicklas",
-                    "sourceNumber": "+46701234567",
-                    "timestamp": timestamp,
-                    "dataMessage": {
-                        "message": (
-                            "7S RAPPORT\n"
-                            "Till: TST\n"
-                            "Från: TS\n"
-                            "TNR: 221520\n"
-                            "Stund: 221520\n"
-                            "Ställe: 34VCM 79349 26095, Långkärrsvägen\n"
-                            "Styrka: 1\n"
-                            "Slag: Vi\n"
-                            "Sysselsättning: Patrull\n"
-                            "Symbol: ABC123 och logotyp-fragment DGE\n"
-                            "Sagesman: AQ\n"
-                            "Sedan: Återgår till bas\n"
-                        ),
-                        "groupV2": {"name": "7s-test", "id": "group123"},
-                    },
-                }
-            }
+            msg_data = _make_msg_data(
+                stalle="34VCM 79349 26095, Långkärrsvägen",
+                symbol="ABC123 och logotyp-fragment DGE",
+            )
 
             handled = await pipeline.run(
                 msg_data=msg_data,
@@ -119,34 +118,8 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
             (group_dir / "TNR221520.md").write_text("existing\n", encoding="utf-8")
 
             pipeline = SevenSPipeline()
-            timestamp = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
-            msg_data = {
-                "envelope": {
-                    "sourceName": "Nicklas",
-                    "sourceNumber": "+46701234567",
-                    "timestamp": timestamp,
-                    "dataMessage": {
-                        "message": (
-                            "7S RAPPORT\n"
-                            "Till: TST\n"
-                            "Från: TS\n"
-                            "TNR: 221520\n"
-                            "Stund: 221520\n"
-                            "Ställe: Långkärrsvägen\n"
-                            "Styrka: 1\n"
-                            "Slag: Vi\n"
-                            "Sysselsättning: Patrull\n"
-                            "Symbol: Svart\n"
-                            "Sagesman: AQ\n"
-                            "Sedan: Återgår till bas\n"
-                        ),
-                        "groupV2": {"name": "7s-test", "id": "group123"},
-                    },
-                }
-            }
-
             handled = await pipeline.run(
-                msg_data=msg_data,
+                msg_data=_make_msg_data(),
                 reader=AsyncMock(),
                 writer=AsyncMock(),
             )
@@ -189,35 +162,9 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
             pipeline = SevenSPipeline()
-            timestamp = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
-            msg_data = {
-                "envelope": {
-                    "sourceName": "Nicklas",
-                    "sourceNumber": "+46701234567",
-                    "timestamp": timestamp,
-                    "dataMessage": {
-                        "message": (
-                            "7S RAPPORT\n"
-                            "Till: TST\n"
-                            "Från: TS\n"
-                            "TNR: 221520\n"
-                            "Stund: 221520\n"
-                            "Ställe: Långkärrsvägen\n"
-                            "Styrka: 1\n"
-                            "Slag: Vi\n"
-                            "Sysselsättning: Patrull\n"
-                            "Symbol: Svart\n"
-                            "Sagesman: 2A GRUPP\n"
-                            "Sedan: Återgår till bas\n"
-                        ),
-                        "groupV2": {"name": "7s-test", "id": "group123"},
-                    },
-                }
-            }
-
             with self.assertRaisesRegex(ValueError, "Sagesman"):
                 await pipeline.run(
-                    msg_data=msg_data,
+                    msg_data=_make_msg_data(sagesman="2A GRUPP"),
                     reader=AsyncMock(),
                     writer=AsyncMock(),
                 )

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -1,6 +1,10 @@
+import datetime
+import tempfile
 import unittest
-from unittest.mock import AsyncMock, Mock, mock_open, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
 
+from oden import config as cfg
 from oden.pipelines.seven_s import SevenSPipeline, is_7s_message, parse_7s_report
 
 
@@ -23,7 +27,7 @@ class TestSevenSPipelineHelpers(unittest.TestCase):
             "Slag: Personbil\n"
             "Sysselsättning: Spanar\n"
             "Symbol: Svart\n"
-            "Sagesman: 2A GRUPP\n"
+            "Sagesman: AQ\n"
             "Sedan: Fortsätter spaning\n"
         )
 
@@ -42,55 +46,120 @@ class TestSevenSPipelineHelpers(unittest.TestCase):
 
 
 class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
-    @patch("oden.pipelines.seven_s.open", new_callable=mock_open)
-    @patch("oden.pipelines.seven_s.os.makedirs")
-    @patch("oden.pipelines.seven_s.get_message_filepath")
     @patch("oden.pipelines.seven_s.get_app_state")
-    async def test_run_handles_7s_and_writes_file(self, mock_get_app_state, mock_get_path, mock_makedirs, mock_file):
-        mock_get_path.return_value = "/tmp/vault/7s/220932-test.md"
-
+    @patch("oden.config.REGEX_PATTERNS", {"custom_feature": r"logotyp-fragment DGE"})
+    async def test_run_handles_7s_and_writes_spec_file(self, mock_get_app_state):
         app_state = Mock()
         app_state.resolve_contact_name.return_value = "Nicklas"
         mock_get_app_state.return_value = app_state
 
-        pipeline = SevenSPipeline()
-        msg_data = {
-            "envelope": {
-                "sourceName": "Nicklas",
-                "sourceNumber": "+46701234567",
-                "timestamp": 1765890600000,
-                "dataMessage": {
-                    "message": (
-                        "7S RAPPORT\n"
-                        "Till: TILL_NAMN\n"
-                        "Från: FRAN_NAMN\n"
-                        "TNR: 220932\n"
-                        "Stund: 220930\n"
-                        "Ställe: 33VXF 56007 96107\n"
-                        "Styrka: 2\n"
-                        "Slag: Personbil\n"
-                        "Sysselsättning: Spanar\n"
-                        "Symbol: Svart\n"
-                        "Sagesman: 2A GRUPP\n"
-                        "Sedan: Fortsätter spaning\n"
-                    ),
-                    "groupV2": {"name": "7s-test", "id": "group123"},
-                },
+        with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
+            pipeline = SevenSPipeline()
+            timestamp = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
+            msg_data = {
+                "envelope": {
+                    "sourceName": "Nicklas",
+                    "sourceNumber": "+46701234567",
+                    "timestamp": timestamp,
+                    "dataMessage": {
+                        "message": (
+                            "7S RAPPORT\n"
+                            "Till: TST\n"
+                            "Från: TS\n"
+                            "TNR: 221520\n"
+                            "Stund: 221520\n"
+                            "Ställe: 34VCM 79349 26095, Långkärrsvägen\n"
+                            "Styrka: 1\n"
+                            "Slag: Vi\n"
+                            "Sysselsättning: Patrull\n"
+                            "Symbol: ABC123 och logotyp-fragment DGE\n"
+                            "Sagesman: AQ\n"
+                            "Sedan: Återgår till bas\n"
+                        ),
+                        "groupV2": {"name": "7s-test", "id": "group123"},
+                    },
+                }
             }
-        }
 
-        handled = await pipeline.run(
-            msg_data=msg_data,
-            reader=AsyncMock(),
-            writer=AsyncMock(),
-        )
+            handled = await pipeline.run(
+                msg_data=msg_data,
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
 
-        self.assertTrue(handled)
-        mock_makedirs.assert_called_once()
-        mock_file.assert_called_once_with("/tmp/vault/7s/220932-test.md", "w", encoding="utf-8")
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "7s-test" / "TNR221520.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
 
-    @patch("oden.pipelines.seven_s.open", new_callable=mock_open)
-    async def test_run_skips_non_7s(self, mock_file):
+        self.assertIn('typ: 7S-rapport', content)
+        self.assertIn('tnr: "221520"', content)
+        self.assertIn('tidpunkt: "2026-06-22T15:20:00"', content)
+        self.assertIn('plats: "Långkärrsvägen"', content)
+        self.assertIn('lat: 59.49063', content)
+        self.assertIn('lon: 17.46740', content)
+        self.assertIn('location: "59.49063,17.46740"', content)
+        self.assertIn('sagesman: AQ', content)
+        self.assertIn('**TNR:** 221520', content)
+        self.assertIn('**Stund:** 2026-06-22 15:20', content)
+        self.assertIn('**Ställe:** Långkärrsvägen', content)
+        self.assertIn('**Symbol:** [[ABC123]] och [[logotyp-fragment DGE]]', content)
+        self.assertNotIn('# 7S RAPPORT', content)
+        self.assertNotIn('## Metadata', content)
+
+    @patch("oden.pipelines.seven_s.get_app_state")
+    async def test_run_adds_collision_suffix_to_filename_and_tnr(self, mock_get_app_state):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
+            group_dir = Path(tmpdir) / "7s-test"
+            group_dir.mkdir(parents=True, exist_ok=True)
+            (group_dir / "TNR221520.md").write_text("existing\n", encoding="utf-8")
+
+            pipeline = SevenSPipeline()
+            timestamp = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
+            msg_data = {
+                "envelope": {
+                    "sourceName": "Nicklas",
+                    "sourceNumber": "+46701234567",
+                    "timestamp": timestamp,
+                    "dataMessage": {
+                        "message": (
+                            "7S RAPPORT\n"
+                            "Till: TST\n"
+                            "Från: TS\n"
+                            "TNR: 221520\n"
+                            "Stund: 221520\n"
+                            "Ställe: Långkärrsvägen\n"
+                            "Styrka: 1\n"
+                            "Slag: Vi\n"
+                            "Sysselsättning: Patrull\n"
+                            "Symbol: Svart\n"
+                            "Sagesman: AQ\n"
+                            "Sedan: Återgår till bas\n"
+                        ),
+                        "groupV2": {"name": "7s-test", "id": "group123"},
+                    },
+                }
+            }
+
+            handled = await pipeline.run(
+                msg_data=msg_data,
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = group_dir / "TNR221520_2.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn('tnr: "221520_2"', content)
+        self.assertIn('**TNR:** 221520_2', content)
+
+    async def test_run_skips_non_7s(self):
         pipeline = SevenSPipeline()
         msg_data = {
             "envelope": {
@@ -111,4 +180,44 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertFalse(handled)
-        mock_file.assert_not_called()
+
+    @patch("oden.pipelines.seven_s.get_app_state")
+    async def test_run_rejects_invalid_sagesman_for_schema(self, mock_get_app_state):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
+            pipeline = SevenSPipeline()
+            timestamp = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
+            msg_data = {
+                "envelope": {
+                    "sourceName": "Nicklas",
+                    "sourceNumber": "+46701234567",
+                    "timestamp": timestamp,
+                    "dataMessage": {
+                        "message": (
+                            "7S RAPPORT\n"
+                            "Till: TST\n"
+                            "Från: TS\n"
+                            "TNR: 221520\n"
+                            "Stund: 221520\n"
+                            "Ställe: Långkärrsvägen\n"
+                            "Styrka: 1\n"
+                            "Slag: Vi\n"
+                            "Sysselsättning: Patrull\n"
+                            "Symbol: Svart\n"
+                            "Sagesman: 2A GRUPP\n"
+                            "Sedan: Återgår till bas\n"
+                        ),
+                        "groupV2": {"name": "7s-test", "id": "group123"},
+                    },
+                }
+            }
+
+            with self.assertRaisesRegex(ValueError, "Sagesman"):
+                await pipeline.run(
+                    msg_data=msg_data,
+                    reader=AsyncMock(),
+                    writer=AsyncMock(),
+                )


### PR DESCRIPTION
## Summary
- align the 7S pipeline output with the documented format spec and frontmatter schema
- update the 7S tests to cover the new filename, frontmatter, body ordering, links, and collision handling
- refresh README and pipeline docs, and add the formal 7S format/schema reference docs

## Testing
- /Users/nicklas/dev/oden/.venv/bin/python -m pytest tests/test_seven_s_pipeline.py tests/test_pipeline_orchestrator.py