### PR TITLE
fix: relax seven_s validation and improve message observability

### DIFF
--- a/docs/7S_frontmatter.schema.json
+++ b/docs/7S_frontmatter.schema.json
@@ -10,6 +10,9 @@
     "typ",
     "tnr",
     "tidpunkt",
+    "signal_tidpunkt",
+    "signal_avsandare_nummer",
+    "signal_avsandare_id",
     "plats",
     "sagesman"
   ],
@@ -42,6 +45,30 @@
       "description": "ISO 8601 local datetime (no timezone offset). The authoritative timestamp of the observation.",
       "examples": [
         "2026-02-14T07:55:00"
+      ]
+    },
+    "signal_tidpunkt": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$",
+      "description": "ISO 8601 local datetime (no timezone offset) for when the Signal message was received.",
+      "examples": [
+        "2026-02-14T08:12:34"
+      ]
+    },
+    "signal_avsandare_nummer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Sender phone number from the Signal message.",
+      "examples": [
+        "+46701234567"
+      ]
+    },
+    "signal_avsandare_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Sender Signal identifier from the message, typically a UUID.",
+      "examples": [
+        "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
       ]
     },
     "plats": {

--- a/docs/7S_frontmatter.schema.json
+++ b/docs/7S_frontmatter.schema.json
@@ -30,7 +30,7 @@
     "tnr": {
       "type": "string",
       "pattern": "^[0-9]{6}(_[0-9]+)?$",
-      "description": "Tidsnummer DDHHMM, optionally with a collision suffix _n. String (may carry leading zeros and underscore). Matches the filename TNR part without the 'TNR' prefix.",
+      "description": "Report TNR DDHHMM, optionally with a collision suffix _n. String (may carry leading zeros and underscore). Matches the filename TNR part without the 'TNR' prefix. This value is preserved from the incoming 7S report and may differ from the observation time in 'tidpunkt'.",
       "examples": [
         "140755",
         "140755_2"
@@ -73,10 +73,11 @@
     },
     "sagesman": {
       "type": "string",
-      "pattern": "^[A-E]Q$",
-      "description": "Reporting unit call sign. Company QO; line platoons AQ/BQ/CQ/DQ, staff platoon EQ. (Production may use finer signs; widen this pattern then.)",
+      "minLength": 1,
+      "description": "Reporting unit call sign as provided in the 7S report. Canonical platoon-level values are AQ/BQ/CQ/DQ/EQ, but production may use finer-grained signals; consumers should treat non-canonical values as warnings rather than schema failures.",
       "examples": [
         "AQ",
+        "2A GRUPP",
         "CQ",
         "EQ"
       ]

--- a/docs/FORMAT_SPEC.md
+++ b/docs/FORMAT_SPEC.md
@@ -56,6 +56,10 @@ Varje fil består av två delar:
 En tom rad skiljer frontmatter från kropp. Filen är UTF-8, LF-radslut, och
 avslutas med en avslutande nyrad.
 
+Med **frontmatter** avses alltså YAML-blocket högst upp i filen, mellan de två
+`---`-raderna. Det är filens maskinläsbara metadata, separerat från den
+människoläsbara rapportkroppen.
+
 ---
 
 ## 4. Frontmatter (YAML)
@@ -120,16 +124,23 @@ kolon, och åtskilda av en tom rad. TNR upprepas först i kroppen för läsbarhe
 
 Fälten (7S):
 
+Notation i tabellen nedan: uttrycket `= frontmatter <nyckel>` betyder att samma
+uppgift också ska finnas i YAML-frontmatteren högst upp i filen. Det betyder
+inte att olika 7S-fält måste vara lika med varandra bara för att de båda
+refererar till frontmatter. Exempel: `TNR` i kroppen hämtas från frontmatter
+`tnr`, medan `Stund` i kroppen återger frontmatter `tidpunkt` i ett annat,
+människoläsbart format.
+
 | Fält              | Innehåll |
 |-------------------|----------|
-| `TNR`             | = frontmatter `tnr`. |
-| `Stund`           | Tidpunkt, människoläsbar `YYYY-MM-DD HH:MM` (utan sekunder). Samma ögonblick som `tidpunkt`. |
-| `Ställe`          | = frontmatter `plats` (utan citationstecken). |
+| `TNR`             | Samma uppgift som i frontmatter `tnr`, återgiven i kroppen för läsbarhet. |
+| `Stund`           | Samma tidpunkt som i frontmatter `tidpunkt`, men i människoläsbar form `YYYY-MM-DD HH:MM` (utan sekunder). |
+| `Ställe`          | Samma uppgift som i frontmatter `plats`, men utan citationstecken. |
 | `Styrka`          | Antal/styrka. Ex: `1 fordon`, `2 personer`, `1 fordon, 2 personer`, `Familj (3-4)`. |
 | `Slag`            | Typ av observation. Ex: `Person`, `Fordon`, `Fordon + person`, `Person (cykel)`, `Fordon (jordbruk)`. |
 | `Sysselsättning`  | Vad de gör. Fritext, en mening. |
 | `Symbol`          | Särskiljande kännetecken. **Här placeras länkar** (§6). |
-| `Sagesman`        | = frontmatter `sagesman`. |
+| `Sagesman`        | Samma uppgift som i frontmatter `sagesman`, återgiven i kroppen för läsbarhet. |
 
 **Konsistenskrav:** fälten måste vara inbördes förenliga. Ett `Slag: Fordon`
 får inte ha `Sysselsättning` eller `Symbol` som beskriver en fotgängare, och

--- a/docs/FORMAT_SPEC.md
+++ b/docs/FORMAT_SPEC.md
@@ -27,7 +27,7 @@ Obsidian-plugin) som läser dessa filer. Applikationens uppgift är att producer
 
 ## 2. Filnamn
 
-```
+```text
 TNR<DDHHMM>[_<n>].md
 ```
 
@@ -83,22 +83,23 @@ sagesman: AQ
 ---
 ```
 
-| Nyckel      | Typ      | Regler |
-|-------------|----------|--------|
-| `id`        | sträng   | Stabil unik identifierare. Format `7S-NNN` i exempeldata; valfri stabil sträng i drift (t.ex. UUID). Måste vara unik över hela vaulten. |
-| `typ`       | sträng   | Konstant `7S-rapport`. Skiljer rapporter från andra noter i grafvyn. |
-| `tnr`       | sträng   | Samma som filnamnets TNR-del, **utan** `TNR`-prefix och **utan** `.md`. Hämtas från inmatningens `TNR` och kan därför skilja sig från observationstiden. Inkludera ev. kollisionssuffix (`140755_2`). Sträng, inte tal (kan ha ledande nollor och `_`). |
-| `tidpunkt`  | sträng   | ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Observationens tidpunkt. Detta är den auktoritativa tidsstämpeln. |
-| `signal_tidpunkt` | sträng | ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Tidpunkten då Signal-meddelandet togs emot. Hämtas från Signals mottagningstidsstämpel när den finns. |
-| `signal_avsandare_nummer` | sträng | Avsändarens nummer i Signal-meddelandet. Citeras som sträng för att behålla exakt värde. |
-| `signal_avsandare_id` | sträng | Avsändarens Signal-id från meddelandet, normalt en UUID. Citeras som sträng för att behålla exakt värde. |
-| `plats`     | sträng   | Fritext-platsnamn. **Citerad** (dubbelfnuttar) eftersom den kan innehålla specialtecken. |
-| `lat`       | tal      | WGS84 decimalgrader, 5 decimaler. Nordlig latitud positiv. |
-| `lon`       | tal      | WGS84 decimalgrader, 5 decimaler. Östlig longitud positiv. |
-| `location`  | sträng   | Kombinerad koordinat `"lat,lon"` för kartvy (§8). **Krävs när koordinater finns** och måste spegla `lat`/`lon` exakt. Utelämnas helt om koordinater saknas. |
-| `sagesman`  | sträng   | Anropssignal för rapporterande enhet (§7). |
+Nycklar:
+
+- `id` — sträng. Stabil unik identifierare. Format `7S-NNN` i exempeldata; valfri stabil sträng i drift (t.ex. UUID). Måste vara unik över hela vaulten.
+- `typ` — sträng. Konstant `7S-rapport`. Skiljer rapporter från andra noter i grafvyn.
+- `tnr` — sträng. Samma som filnamnets TNR-del, **utan** `TNR`-prefix och **utan** `.md`. Hämtas från inmatningens `TNR` och kan därför skilja sig från observationstiden. Inkludera ev. kollisionssuffix (`140755_2`). Sträng, inte tal (kan ha ledande nollor och `_`).
+- `tidpunkt` — sträng. ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Observationens tidpunkt. Detta är den auktoritativa tidsstämpeln.
+- `signal_tidpunkt` — sträng. ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Tidpunkten då Signal-meddelandet togs emot. Hämtas från Signals mottagningstidsstämpel när den finns.
+- `signal_avsandare_nummer` — sträng. Avsändarens nummer i Signal-meddelandet. Citeras som sträng för att behålla exakt värde.
+- `signal_avsandare_id` — sträng. Avsändarens Signal-id från meddelandet, normalt en UUID. Citeras som sträng för att behålla exakt värde.
+- `plats` — sträng. Fritext-platsnamn. **Citerad** (dubbelfnuttar) eftersom den kan innehålla specialtecken.
+- `lat` — tal. WGS84 decimalgrader, 5 decimaler. Nordlig latitud positiv.
+- `lon` — tal. WGS84 decimalgrader, 5 decimaler. Östlig longitud positiv.
+- `location` — sträng. Kombinerad koordinat `"lat,lon"` för kartvy (§8). **Krävs när koordinater finns** och måste spegla `lat`/`lon` exakt. Utelämnas helt om koordinater saknas.
+- `sagesman` — sträng. Anropssignal för rapporterande enhet (§7).
 
 Regler:
+
 - Saknas koordinater för en observation: utelämna `lat`, `lon` **och**
   `location` helt (skriv dem inte som `null` eller `0`). `plats` bör ändå anges
   som fritext.
@@ -141,17 +142,17 @@ refererar till frontmatter. Exempel: `TNR` i kroppen hämtas från frontmatter
 `tnr`, medan `Stund` i kroppen återger frontmatter `tidpunkt` i ett annat,
 människoläsbart format.
 
-| Fält              | Innehåll |
-|-------------------|----------|
-| `TNR`             | Samma uppgift som i frontmatter `tnr`, återgiven i kroppen för läsbarhet. |
-| `Stund`           | Samma tidpunkt som i frontmatter `tidpunkt`, men i människoläsbar form `YYYY-MM-DD HH:MM` (utan sekunder). |
-| `Ställe`          | Samma uppgift som i frontmatter `plats`, men utan citationstecken. |
-| `Styrka`          | Antal/styrka. Ex: `1 fordon`, `2 personer`, `1 fordon, 2 personer`, `Familj (3-4)`. |
-| `Slag`            | Typ av observation. Ex: `Person`, `Fordon`, `Fordon + person`, `Person (cykel)`, `Fordon (jordbruk)`. |
-| `Sysselsättning`  | Vad de gör. Fritext, en mening. |
-| `Symbol`          | Särskiljande kännetecken. **Här placeras länkar** (§6). |
-| `Sagesman`        | Samma uppgift som i frontmatter `sagesman`, återgiven i kroppen för läsbarhet. |
-| `Sedan`           | Valfritt extra S efter `Sagesman`. Beskriver vad patrullen gör efter observationen. Ingen separat frontmatter-nyckel krävs. |
+Fält:
+
+- `TNR` — samma uppgift som i frontmatter `tnr`, återgiven i kroppen för läsbarhet.
+- `Stund` — samma tidpunkt som i frontmatter `tidpunkt`, men i människoläsbar form `YYYY-MM-DD HH:MM` (utan sekunder).
+- `Ställe` — samma uppgift som i frontmatter `plats`, men utan citationstecken.
+- `Styrka` — antal/styrka. Ex: `1 fordon`, `2 personer`, `1 fordon, 2 personer`, `Familj (3-4)`.
+- `Slag` — typ av observation. Ex: `Person`, `Fordon`, `Fordon + person`, `Person (cykel)`, `Fordon (jordbruk)`.
+- `Sysselsättning` — vad de gör. Fritext, en mening.
+- `Symbol` — särskiljande kännetecken. **Här placeras länkar** (§6).
+- `Sagesman` — samma uppgift som i frontmatter `sagesman`, återgiven i kroppen för läsbarhet.
+- `Sedan` — valfritt extra S efter `Sagesman`. Beskriver vad patrullen gör efter observationen. Ingen separat frontmatter-nyckel krävs.
 
 **Konsistenskrav:** fälten måste vara inbördes förenliga. Ett `Slag: Fordon`
 får inte ha `Sysselsättning` eller `Symbol` som beskriver en fotgängare, och
@@ -167,11 +168,11 @@ Den centrala applikationen identifierar särskiljande kännetecken i fält
 
 ### 6.1 Vad som ska länkas
 
-| Kategori | Regel | Exempel i text |
-|----------|-------|----------------|
-| Fullständig nummerplåt | Svenskt format (§6.3) | `reg [[RJK241]]` |
-| Partiell nummerplåt | Plåt där tecken saknas; maskera saknade positioner med `.` (§6.4) | `reg [[..G41.]]` |
-| Annat distinkt kännetecken som matchas regelbundet | Kanoniserad etikett (§6.5) | `[[logotyp-fragment DGE]]` |
+Kategorier:
+
+- Fullständig nummerplåt: Svenskt format (§6.3). Exempel i text: `reg [[RJK241]]`.
+- Partiell nummerplåt: Plåt där tecken saknas; maskera saknade positioner med `.` (§6.4). Exempel i text: `reg [[..G41.]]`.
+- Annat distinkt kännetecken som matchas regelbundet: kanoniserad etikett (§6.5). Exempel i text: `[[logotyp-fragment DGE]]`.
 
 ### 6.2 Vad som INTE ska länkas
 
@@ -184,6 +185,7 @@ Den centrala applikationen identifierar särskiljande kännetecken i fält
 ### 6.3 Svenskt nummerplåtsformat (fullständig)
 
 Två giltiga mönster:
+
 - `AAA NNN` — tre bokstäver, tre siffror.
 - `AAA NNL` — tre bokstäver, två siffror, en bokstav.
 
@@ -193,7 +195,8 @@ Tillåtna bokstäver: `A-Z` utom `I O Q V` (svensk konvention, undviker
 förväxling). Använd versaler.
 
 Regex (fullständig plåt):
-```
+
+```regex
 ^[ABCDEFGHJKLMNPRSTUWXYZ]{3}[0-9]{2}[0-9ABCDEFGHJKLMNPRSTUWXYZ]$
 ```
 
@@ -209,7 +212,8 @@ som en regex-wildcard mot den fullständiga plåten.
 - Behåll total längd (6 tecken).
 
 Regex (partiell plåt — minst en punkt, i övrigt giltig struktur):
-```
+
+```regex
 ^[A-Z.]{3}[0-9.]{2}[0-9A-Z.]$   (och innehåller minst ett '.')
 ```
 
@@ -226,6 +230,7 @@ samma kännetecken alltid ger samma länktext (och därmed samma nod). Etiketten
 är kort beskrivande svenska, gemener.
 
 Exempel som används i testdata:
+
 - `[[logotyp-fragment DGE]]`
 - `[[ryggsäck märkning delvis läsbar -TAC]]`
 - `[[keps mörk med ljust emblem]]`
@@ -247,13 +252,13 @@ entitetsnoter är analyssteget (plugin).
 
 Kompani med huvudanropssignal **QO**. Plutoner:
 
-| Signal | Pluton |
-|--------|--------|
-| `AQ`   | 1. skyttepluton (linje) |
-| `BQ`   | 2. skyttepluton (linje) |
-| `CQ`   | 3. skyttepluton (linje) |
-| `DQ`   | 4. skyttepluton (linje) |
-| `EQ`   | stabspluton |
+Plutoner:
+
+- `AQ` — 1. skyttepluton (linje)
+- `BQ` — 2. skyttepluton (linje)
+- `CQ` — 3. skyttepluton (linje)
+- `DQ` — 4. skyttepluton (linje)
+- `EQ` — stabspluton
 
 I drift kan finare signaler förekomma; för detta format räcker plutonsnivå.
 Oden bevarar inkommande `sagesman` även när värdet avviker från `AQ`-`EQ`, men

--- a/docs/FORMAT_SPEC.md
+++ b/docs/FORMAT_SPEC.md
@@ -72,6 +72,9 @@ id: 7S-004
 typ: 7S-rapport
 tnr: "140755"
 tidpunkt: "2026-02-14T07:55:00"
+signal_tidpunkt: "2026-02-14T08:12:34"
+signal_avsandare_nummer: "+46701234567"
+signal_avsandare_id: "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
 plats: "Grusparkering vid motionsspåret"
 lat: 59.26608
 lon: 17.70644
@@ -86,6 +89,9 @@ sagesman: AQ
 | `typ`       | sträng   | Konstant `7S-rapport`. Skiljer rapporter från andra noter i grafvyn. |
 | `tnr`       | sträng   | Samma som filnamnets TNR-del, **utan** `TNR`-prefix och **utan** `.md`. Hämtas från inmatningens `TNR` och kan därför skilja sig från observationstiden. Inkludera ev. kollisionssuffix (`140755_2`). Sträng, inte tal (kan ha ledande nollor och `_`). |
 | `tidpunkt`  | sträng   | ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Observationens tidpunkt. Detta är den auktoritativa tidsstämpeln. |
+| `signal_tidpunkt` | sträng | ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Tidpunkten då Signal-meddelandet togs emot. Hämtas från Signals mottagningstidsstämpel när den finns. |
+| `signal_avsandare_nummer` | sträng | Avsändarens nummer i Signal-meddelandet. Citeras som sträng för att behålla exakt värde. |
+| `signal_avsandare_id` | sträng | Avsändarens Signal-id från meddelandet, normalt en UUID. Citeras som sträng för att behålla exakt värde. |
 | `plats`     | sträng   | Fritext-platsnamn. **Citerad** (dubbelfnuttar) eftersom den kan innehålla specialtecken. |
 | `lat`       | tal      | WGS84 decimalgrader, 5 decimaler. Nordlig latitud positiv. |
 | `lon`       | tal      | WGS84 decimalgrader, 5 decimaler. Östlig longitud positiv. |
@@ -103,8 +109,10 @@ Regler:
 
 ## 5. Rapportkropp (7S)
 
-Exakt dessa sju fält, i denna ordning, var och en med **fet** etikett följd av
+Exakt dessa sju kärnfält, i denna ordning, var och en med **fet** etikett följd av
 kolon, och åtskilda av en tom rad. TNR upprepas först i kroppen för läsbarhet.
+Efter `Sagesman` får ett valfritt extra S-fält, `Sedan`, förekomma när
+rapporten anger vad patrullen gör efter observationen.
 
 ```markdown
 **TNR:** 140755
@@ -120,6 +128,8 @@ kolon, och åtskilda av en tom rad. TNR upprepas först i kroppen för läsbarhe
 **Sysselsättning:** Fiskade vid vattnet.
 
 **Sagesman:** AQ
+
+**Sedan:** Återgår till bas.
 ```
 
 Fälten (7S):
@@ -141,6 +151,7 @@ människoläsbart format.
 | `Sysselsättning`  | Vad de gör. Fritext, en mening. |
 | `Symbol`          | Särskiljande kännetecken. **Här placeras länkar** (§6). |
 | `Sagesman`        | Samma uppgift som i frontmatter `sagesman`, återgiven i kroppen för läsbarhet. |
+| `Sedan`           | Valfritt extra S efter `Sagesman`. Beskriver vad patrullen gör efter observationen. Ingen separat frontmatter-nyckel krävs. |
 
 **Konsistenskrav:** fälten måste vara inbördes förenliga. Ett `Slag: Fordon`
 får inte ha `Sysselsättning` eller `Symbol` som beskriver en fotgängare, och
@@ -295,6 +306,9 @@ id: 7S-004
 typ: 7S-rapport
 tnr: "140755"
 tidpunkt: "2026-02-14T07:55:00"
+signal_tidpunkt: "2026-02-14T08:12:34"
+signal_avsandare_nummer: "+46701234567"
+signal_avsandare_id: "b1f2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
 plats: "Vägren E4 avfart söderut"
 lat: 59.25401
 lon: 17.69812

--- a/docs/FORMAT_SPEC.md
+++ b/docs/FORMAT_SPEC.md
@@ -32,8 +32,10 @@ TNR<DDHHMM>[_<n>].md
 ```
 
 - `TNR` — fast prefix (versaler).
-- `DDHHMM` — tidsnummer ur observationens tidpunkt: dag-i-månad, timme, minut,
-  nollutfyllt tvåsiffrigt (UTC-offset enligt §4). Ex: 14 feb 07:55 → `140755`.
+- `DDHHMM` — rapportens eget tidsnummer som kommer från fältet `TNR` i 7S-inmatningen.
+  Formatet är dag-i-månad, timme, minut, nollutfyllt tvåsiffrigt. Det är ofta samma
+  som observationstiden men behöver inte vara det, eftersom `Stund` avser när
+  observationen gjordes medan `TNR` kan avse när rapporten skickades in.
 - `_<n>` — kollisionssuffix. Om en fil med samma TNR redan finns läggs `_2`,
   `_3`, … till i ankomstordning. Första filen får inget suffix.
 - Exempel: `TNR140755.md`, `TNR140755_2.md`.
@@ -78,7 +80,7 @@ sagesman: AQ
 |-------------|----------|--------|
 | `id`        | sträng   | Stabil unik identifierare. Format `7S-NNN` i exempeldata; valfri stabil sträng i drift (t.ex. UUID). Måste vara unik över hela vaulten. |
 | `typ`       | sträng   | Konstant `7S-rapport`. Skiljer rapporter från andra noter i grafvyn. |
-| `tnr`       | sträng   | Samma som filnamnets TNR-del, **utan** `TNR`-prefix och **utan** `.md`. Inkludera ev. kollisionssuffix (`140755_2`). Sträng, inte tal (kan ha ledande nollor och `_`). |
+| `tnr`       | sträng   | Samma som filnamnets TNR-del, **utan** `TNR`-prefix och **utan** `.md`. Hämtas från inmatningens `TNR` och kan därför skilja sig från observationstiden. Inkludera ev. kollisionssuffix (`140755_2`). Sträng, inte tal (kan ha ledande nollor och `_`). |
 | `tidpunkt`  | sträng   | ISO 8601 lokal tid, `YYYY-MM-DDTHH:MM:SS`. Observationens tidpunkt. Detta är den auktoritativa tidsstämpeln. |
 | `plats`     | sträng   | Fritext-platsnamn. **Citerad** (dubbelfnuttar) eftersom den kan innehålla specialtecken. |
 | `lat`       | tal      | WGS84 decimalgrader, 5 decimaler. Nordlig latitud positiv. |
@@ -232,6 +234,9 @@ Kompani med huvudanropssignal **QO**. Plutoner:
 | `EQ`   | stabspluton |
 
 I drift kan finare signaler förekomma; för detta format räcker plutonsnivå.
+Oden bevarar inkommande `sagesman` även när värdet avviker från `AQ`-`EQ`, men
+bör logga en varning för att markera att signalen inte följer den kanoniska
+plutonsnivån.
 Geografisk koppling (en pluton ansvarar normalt för en sektor) är en
 *egenskap hos insatsen*, inte ett formatkrav.
 

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -49,8 +49,11 @@ Nuvarande default:
 
 **Vad den gör:**
 - Parsar strukturerad 7S-rapport (Till, Från, TNR, Stund, Ställe, Styrka, Slag, Sysselsättning, Symbol, Sagesman, Sedan)
-- Validerar alla obligatoriska fält och schemakritiska värden som `TNR`, `Stund` och `Sagesman`
-- Skriver strukturerad markdown-fil till `vault/{group_name}/TNR<DDHHMM>[_n].md`
+- Validerar alla obligatoriska fält samt att `TNR` och `Stund` båda följer formatet `DDHHMM`
+- Tolkar `Stund` som observationstid och bevarar `TNR` som rapportens eget tidsnummer, även när de skiljer sig
+- Loggar en varning om `Sagesman` avviker från den kanoniska plutonsnivån (`AQ`-`EQ`), men skriver rapporten ändå
+- Sparar sådana avvikelser som `pipeline_warning` i meddelandets pipeline-events så att de syns i observability-vyn
+- Skriver strukturerad markdown-fil till `vault/{group_name}/TNR<DDHHMM>[_n].md`, där filnamnet följer rapportens `TNR`
 - Genererar schemaformad YAML-frontmatter enligt [FORMAT_SPEC.md](FORMAT_SPEC.md) och [7S_frontmatter.schema.json](7S_frontmatter.schema.json)
 - Konverterar MGRS i `Ställe` till `lat`, `lon` och `location` när koordinater kan härledas
 - Länkar särskiljande kännetecken i `Symbol` med `[[...]]` enligt specen

--- a/oden/messages_db.py
+++ b/oden/messages_db.py
@@ -120,6 +120,7 @@ def list_messages(
     account: str | None = None,
     status: str | None = None,
     group_id: str | None = None,
+    has_content_only: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
@@ -140,6 +141,8 @@ def list_messages(
     if group_id:
         conditions.append("group_id = ?")
         params.append(group_id)
+    if has_content_only:
+        conditions.append("COALESCE(TRIM(message_body), '') != ''")
 
     where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
     params.extend([limit, offset])

--- a/oden/pipeline_orchestrator.py
+++ b/oden/pipeline_orchestrator.py
@@ -103,6 +103,17 @@ class PipelineOrchestrator:
                     writer=writer,
                 )
 
+                for warning in getattr(pipeline, "last_warnings", []) or []:
+                    append_pipeline_event(
+                        self._db_path,
+                        run_id,
+                        "pipeline_warning",
+                        {
+                            "pipeline": pipeline.name,
+                            **warning,
+                        },
+                    )
+
                 if handled:
                     complete_pipeline_run(self._db_path, run_id)
                     append_pipeline_event(

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -239,9 +239,7 @@ class SevenSPipeline:
         )
         signal_timestamp_ms = envelope.get("serverReceivedTimestamp") or timestamp_ms
         signal_dt = (
-            datetime.datetime.fromtimestamp(signal_timestamp_ms / 1000, tz=cfg.TIMEZONE)
-            if signal_timestamp_ms
-            else dt
+            datetime.datetime.fromtimestamp(signal_timestamp_ms / 1000, tz=cfg.TIMEZONE) if signal_timestamp_ms else dt
         )
         source_id = envelope.get("sourceUuid")
         if not source_number:

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -35,8 +35,9 @@ _REQUIRED_FIELDS = {
     "sysselsattning",
     "symbol",
     "sagesman",
-    "sedan",
 }
+
+_OPTIONAL_FIELDS = {"sedan"}
 
 _LABEL_ALIASES = {
     "till": "till",
@@ -174,7 +175,7 @@ def parse_7s_report(message_text: str) -> dict[str, str]:
             continue
         label, value = line.split(":", 1)
         key = _normalize_label(label)
-        if key in _REQUIRED_FIELDS:
+        if key in _REQUIRED_FIELDS or key in _OPTIONAL_FIELDS:
             fields[key] = value.strip()
 
     missing = sorted(_REQUIRED_FIELDS - set(fields.keys()))
@@ -236,6 +237,17 @@ class SevenSPipeline:
             if timestamp_ms
             else datetime.datetime.now(cfg.TIMEZONE)
         )
+        signal_timestamp_ms = envelope.get("serverReceivedTimestamp") or timestamp_ms
+        signal_dt = (
+            datetime.datetime.fromtimestamp(signal_timestamp_ms / 1000, tz=cfg.TIMEZONE)
+            if signal_timestamp_ms
+            else dt
+        )
+        source_id = envelope.get("sourceUuid")
+        if not source_number:
+            raise ValueError("7S Signal sender number is missing")
+        if not source_id:
+            raise ValueError("7S Signal sender id is missing")
 
         raw_tnr = fields["tnr"].strip()
         raw_stund = fields["stund"].strip()
@@ -267,6 +279,7 @@ class SevenSPipeline:
 
         plats, lat, lon = _extract_location(fields["stalle"])
         tidpunkt = observation_dt.strftime("%Y-%m-%dT%H:%M:%S")
+        signal_tidpunkt = signal_dt.strftime("%Y-%m-%dT%H:%M:%S")
         stund_display = observation_dt.strftime("%Y-%m-%d %H:%M")
         symbol_raw = fields["symbol"].strip()
         symbol = _link_remaining_plates(apply_regex_links(symbol_raw) or symbol_raw)
@@ -277,6 +290,9 @@ class SevenSPipeline:
             "typ: 7S-rapport",
             f"tnr: {_yaml_quote(resolved_tnr)}",
             f"tidpunkt: {_yaml_quote(tidpunkt)}",
+            f"signal_tidpunkt: {_yaml_quote(signal_tidpunkt)}",
+            f"signal_avsandare_nummer: {_yaml_quote(source_number)}",
+            f"signal_avsandare_id: {_yaml_quote(source_id)}",
             f"plats: {_yaml_quote(plats)}",
         ]
         if lat is not None and lon is not None:
@@ -309,6 +325,10 @@ class SevenSPipeline:
             f"**Sagesman:** {sagesman}",
             "",
         ]
+
+        sedan = fields.get("sedan", "").strip()
+        if sedan:
+            body_lines.extend([f"**Sedan:** {sedan}", ""])
 
         content = "\n".join(frontmatter_lines + body_lines)
 

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -22,6 +22,8 @@ from oden.app_state import get_app_state
 from oden.formatting import get_safe_group_dir_path
 from oden.link_formatter import apply_regex_links
 
+logger = logging.getLogger(__name__)
+
 _REQUIRED_FIELDS = {
     "till",
     "fran",
@@ -210,6 +212,7 @@ class SevenSPipeline:
         writer: Any,
     ) -> bool:
         del reader, writer  # Not used by this pipeline currently.
+        self.last_warnings: list[dict[str, str]] = []
 
         envelope = msg_data.get("envelope", {})
         if not envelope:
@@ -238,15 +241,26 @@ class SevenSPipeline:
         raw_stund = fields["stund"].strip()
         if not re.fullmatch(r"\d{6}", raw_tnr):
             raise ValueError("7S TNR must be DDHHMM")
-        if raw_tnr != raw_stund:
-            raise ValueError("7S TNR and Stund must match")
+        # TNR identifies the submitted report, while Stund captures when the
+        # observation happened. They are both DDHHMM but may legitimately differ.
+        if not re.fullmatch(r"\d{6}", raw_stund):
+            raise ValueError("7S Stund must be DDHHMM")
 
         sagesman = fields["sagesman"].strip().upper()
         if not re.fullmatch(r"[A-E]Q", sagesman):
-            raise ValueError("7S Sagesman must match schema pattern [A-E]Q")
+            warning = {
+                "field": "sagesman",
+                "value": sagesman,
+                "message": "7S Sagesman is non-canonical; writing report anyway",
+            }
+            self.last_warnings.append(warning)
+            logger.warning(
+                "7S Sagesman is non-canonical (%r); writing report anyway",
+                sagesman,
+            )
 
         observation_dt = _resolve_observation_datetime(raw_stund, dt)
-        resolved_tnr = observation_dt.strftime("%d%H%M")
+        resolved_tnr = raw_tnr
 
         resolved_group_title = group_title or "inbox"
         filepath, resolved_tnr = _build_7s_filepath(resolved_group_title, resolved_tnr)

--- a/oden/templates/web/css/dashboard.css
+++ b/oden/templates/web/css/dashboard.css
@@ -512,6 +512,12 @@ td {
     color: #ced8ea;
     font-size: 0.85em;
 }
+.pipeline-event-warning {
+    color: var(--color-warning);
+}
+.pipeline-event-details {
+    color: var(--color-text-subtle);
+}
 .message-raw-json {
     background: #0a101d;
     border: 1px solid var(--color-border-subtle);
@@ -531,6 +537,12 @@ td {
     gap: 12px;
     margin-top: 14px;
     color: var(--color-text-dim);
+}
+.checkbox-inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-text-subtle);
 }
 
 /* Pipeline management tab */

--- a/oden/templates/web/includes/dashboard/tab_messages.html
+++ b/oden/templates/web/includes/dashboard/tab_messages.html
@@ -12,6 +12,10 @@
                 <option value="ignored">ignored</option>
             </select>
         </div>
+        <label class="checkbox-inline">
+            <input type="checkbox" id="messages-has-content-filter" onchange="loadMessagesDashboard()" checked>
+            Dölj meddelanden utan innehåll
+        </label>
         <button class="btn" onclick="loadMessagesDashboard()">Uppdatera</button>
     </div>
 

--- a/oden/templates/web/js/dashboard/message_queue.js
+++ b/oden/templates/web/js/dashboard/message_queue.js
@@ -4,6 +4,11 @@
 
 let selectedMessageId = null;
 
+function resetMessageDetail(message) {
+    document.getElementById('message-detail').innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+    document.getElementById('btn-reprocess-message').disabled = true;
+}
+
 function formatMessageLabel(msg) {
     const sender = msg.source_name || msg.source_number || 'Okänd';
     const group = msg.group_name || 'inbox';
@@ -40,9 +45,13 @@ function renderMessageDetail(payload) {
 
     const runsHtml = runs.map(run => {
         const events = run.events || [];
-        const eventsHtml = events.map(event =>
-            `<li><strong>${escapeHtml(event.event_type)}</strong> <span>${escapeHtml(event.occurred_at || '')}</span></li>`
-        ).join('');
+        const eventsHtml = events.map(event => {
+            const details = event.details || {};
+            const detailText = details.message || details.error || details.value || '';
+            const detailHtml = detailText ? ` <span class="pipeline-event-details">${escapeHtml(detailText)}</span>` : '';
+            const warningClass = event.event_type === 'pipeline_warning' ? ' pipeline-event-warning' : '';
+            return `<li class="pipeline-event${warningClass}"><strong>${escapeHtml(event.event_type)}</strong> <span>${escapeHtml(event.occurred_at || '')}</span>${detailHtml}</li>`;
+        }).join('');
 
         return `
             <div class="pipeline-run">
@@ -80,7 +89,7 @@ async function loadMessageDetail(messageId) {
         renderMessageDetail(payload);
         document.getElementById('btn-reprocess-message').disabled = false;
     } catch (error) {
-        document.getElementById('message-detail').innerHTML = `<div class="empty-state">Kunde inte ladda detalj: ${escapeHtml(error.message)}</div>`;
+        resetMessageDetail(`Kunde inte ladda detalj: ${error.message}`);
     }
 }
 
@@ -103,9 +112,13 @@ async function loadMessageStats() {
 async function loadMessagesDashboard() {
     try {
         const status = document.getElementById('messages-status-filter').value;
+        const hasContentOnly = document.getElementById('messages-has-content-filter').checked;
         const params = new URLSearchParams({ limit: '100' });
         if (status) {
             params.set('status', status);
+        }
+        if (hasContentOnly) {
+            params.set('has_content', '1');
         }
 
         const response = await fetch(`/api/messages?${params.toString()}`);
@@ -119,11 +132,17 @@ async function loadMessagesDashboard() {
 
         if (selectedMessageId && messages.some(m => m.id === selectedMessageId)) {
             await loadMessageDetail(selectedMessageId);
+        } else if (selectedMessageId) {
+            selectedMessageId = null;
+            resetMessageDetail('Välj ett meddelande i listan.');
+        } else if (!messages.length) {
+            resetMessageDetail('Välj ett meddelande i listan.');
         }
 
         await loadMessageStats();
     } catch (error) {
         document.getElementById('messages-list').innerHTML = `<div class="empty-state">Kunde inte ladda meddelanden: ${escapeHtml(error.message)}</div>`;
+        resetMessageDetail('Välj ett meddelande i listan.');
     }
 }
 

--- a/oden/web_handlers/message_handlers.py
+++ b/oden/web_handlers/message_handlers.py
@@ -32,6 +32,13 @@ def _get_int_query(request: web.Request, key: str, default: int, minimum: int, m
     return max(minimum, min(maximum, value))
 
 
+def _get_bool_query(request: web.Request, key: str) -> bool:
+    value_raw = request.query.get(key)
+    if value_raw is None:
+        return False
+    return value_raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 @handle_errors("list messages")
 async def messages_list_handler(request: web.Request) -> web.Response:
     """List stored raw messages with simple filtering and pagination."""
@@ -41,12 +48,14 @@ async def messages_list_handler(request: web.Request) -> web.Response:
     account = request.query.get("account") or None
     status = request.query.get("status") or None
     group_id = request.query.get("group_id") or None
+    has_content_only = _get_bool_query(request, "has_content")
 
     messages = list_messages(
         cfg.CONFIG_DB,
         account=account,
         status=status,
         group_id=group_id,
+        has_content_only=has_content_only,
         limit=limit,
         offset=offset,
     )
@@ -57,6 +66,7 @@ async def messages_list_handler(request: web.Request) -> web.Response:
             "limit": limit,
             "offset": offset,
             "count": len(messages),
+            "has_content_only": has_content_only,
         }
     )
 

--- a/tests/test_pipeline_orchestrator.py
+++ b/tests/test_pipeline_orchestrator.py
@@ -25,6 +25,15 @@ class _HandlingPipeline:
         return True
 
 
+class _WarningPipeline:
+    name = "warning"
+
+    async def run(self, *, msg_data, reader, writer):
+        del msg_data, reader, writer
+        self.last_warnings = [{"message": "non-canonical sagesman", "field": "sagesman", "value": "2A GRUPP"}]
+        return True
+
+
 class TestPipelineOrchestrator(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
@@ -118,3 +127,24 @@ class TestPipelineOrchestrator(unittest.IsolatedAsyncioTestCase):
         orchestrator = PipelineOrchestrator(self.db_path)
         result = await orchestrator.reprocess(message_id=999999, reader=None, writer=None)
         self.assertFalse(result)
+
+    async def test_run_message_persists_pipeline_warning_events(self):
+        message_id = self._create_sample_message()
+        orchestrator = PipelineOrchestrator(self.db_path)
+        orchestrator._build_pipelines = lambda: [_WarningPipeline()]  # type: ignore[method-assign]
+
+        await orchestrator.run_message(
+            message_id=message_id,
+            msg_data={"envelope": {"dataMessage": {"message": "hej"}}},
+            reader=None,
+            writer=None,
+        )
+
+        runs = get_runs_for_message(self.db_path, message_id)
+        self.assertEqual(len(runs), 1)
+
+        events = get_events_for_run(self.db_path, runs[0]["id"])
+        warning_events = [event for event in events if event["event_type"] == "pipeline_warning"]
+        self.assertEqual(len(warning_events), 1)
+        self.assertEqual(warning_events[0]["details"]["field"], "sagesman")
+        self.assertEqual(warning_events[0]["details"]["value"], "2A GRUPP")

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -22,6 +22,7 @@ def _make_msg_data(
     source_id="dd1bac1d-b955-4ac0-9d53-14053c4fe69f",
     sedan="Återgår till bas",
 ):
+    sedan_line = f"Sedan: {sedan}\n" if sedan is not None else ""
     return {
         "envelope": {
             "sourceName": "Nicklas",
@@ -34,7 +35,7 @@ def _make_msg_data(
                     f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: {tnr}\nStund: {stund}\n"
                     f"Ställe: {stalle}\nStyrka: 1\nSlag: Vi\nSysselsättning: Patrull\n"
                     f"Symbol: {symbol}\nSagesman: {sagesman}\n"
-                    f"{f'Sedan: {sedan}\\n' if sedan is not None else ''}"
+                    f"{sedan_line}"
                 ),
                 "groupV2": {"name": group, "id": "group123"},
             },

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -10,7 +10,9 @@ from oden.pipelines.seven_s import SevenSPipeline, is_7s_message, parse_7s_repor
 _TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
 
 
-def _make_msg_data(*, sagesman="AQ", stalle="Långkärrsvägen", symbol="Svart", group="7s-test"):
+def _make_msg_data(
+    *, sagesman="AQ", stalle="Långkärrsvägen", symbol="Svart", group="7s-test", tnr="221520", stund="221520"
+):
     return {
         "envelope": {
             "sourceName": "Nicklas",
@@ -18,7 +20,7 @@ def _make_msg_data(*, sagesman="AQ", stalle="Långkärrsvägen", symbol="Svart",
             "timestamp": _TIMESTAMP,
             "dataMessage": {
                 "message": (
-                    f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: 221520\nStund: 221520\n"
+                    f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: {tnr}\nStund: {stund}\n"
                     f"Ställe: {stalle}\nStyrka: 1\nSlag: Vi\nSysselsättning: Patrull\n"
                     f"Symbol: {symbol}\nSagesman: {sagesman}\nSedan: Återgår till bas\n"
                 ),
@@ -155,16 +157,49 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(handled)
 
     @patch("oden.pipelines.seven_s.get_app_state")
-    async def test_run_rejects_invalid_sagesman_for_schema(self, mock_get_app_state):
+    async def test_run_allows_distinct_tnr_and_stund(self, mock_get_app_state):
         app_state = Mock()
         app_state.resolve_contact_name.return_value = "Nicklas"
         mock_get_app_state.return_value = app_state
 
         with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
             pipeline = SevenSPipeline()
-            with self.assertRaisesRegex(ValueError, "Sagesman"):
-                await pipeline.run(
+            handled = await pipeline.run(
+                msg_data=_make_msg_data(tnr="221035", stund="221034"),
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "7s-test" / "TNR221035.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn('tnr: "221035"', content)
+        self.assertIn("**TNR:** 221035", content)
+        self.assertIn('tidpunkt: "2026-06-22T10:34:00"', content)
+        self.assertIn("**Stund:** 2026-06-22 10:34", content)
+
+    @patch("oden.pipelines.seven_s.get_app_state")
+    async def test_run_warns_but_writes_invalid_sagesman(self, mock_get_app_state):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
+            pipeline = SevenSPipeline()
+            with self.assertLogs("oden.pipelines.seven_s", level="WARNING") as captured_logs:
+                handled = await pipeline.run(
                     msg_data=_make_msg_data(sagesman="2A GRUPP"),
                     reader=AsyncMock(),
                     writer=AsyncMock(),
                 )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "7s-test" / "TNR221520.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("non-canonical", "\n".join(captured_logs.output))
+        self.assertIn("sagesman: 2A GRUPP", content)
+        self.assertIn("**Sagesman:** 2A GRUPP", content)

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -8,21 +8,33 @@ from oden import config as cfg
 from oden.pipelines.seven_s import SevenSPipeline, is_7s_message, parse_7s_report
 
 _TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
+_SERVER_RECEIVED_TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 9, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
 
 
 def _make_msg_data(
-    *, sagesman="AQ", stalle="Långkärrsvägen", symbol="Svart", group="7s-test", tnr="221520", stund="221520"
+    *,
+    sagesman="AQ",
+    stalle="Långkärrsvägen",
+    symbol="Svart",
+    group="7s-test",
+    tnr="221520",
+    stund="221520",
+    source_id="dd1bac1d-b955-4ac0-9d53-14053c4fe69f",
+    sedan="Återgår till bas",
 ):
     return {
         "envelope": {
             "sourceName": "Nicklas",
             "sourceNumber": "+46701234567",
+            "sourceUuid": source_id,
             "timestamp": _TIMESTAMP,
+            "serverReceivedTimestamp": _SERVER_RECEIVED_TIMESTAMP,
             "dataMessage": {
                 "message": (
                     f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: {tnr}\nStund: {stund}\n"
                     f"Ställe: {stalle}\nStyrka: 1\nSlag: Vi\nSysselsättning: Patrull\n"
-                    f"Symbol: {symbol}\nSagesman: {sagesman}\nSedan: Återgår till bas\n"
+                    f"Symbol: {symbol}\nSagesman: {sagesman}\n"
+                    f"{f'Sedan: {sedan}\\n' if sedan is not None else ''}"
                 ),
                 "groupV2": {"name": group, "id": "group123"},
             },
@@ -60,6 +72,26 @@ class TestSevenSPipelineHelpers(unittest.TestCase):
         self.assertEqual(fields["tnr"], "220932")
         self.assertEqual(fields["stund"], "220930")
         self.assertEqual(fields["stalle"], "33VXF 56007 96107")
+        self.assertEqual(fields["sedan"], "Fortsätter spaning")
+
+    def test_parse_7s_report_allows_missing_optional_sedan(self):
+        text = (
+            "7S RAPPORT\n"
+            "Till: TILL_NAMN\n"
+            "Från: FRAN_NAMN\n"
+            "TNR: 220932\n"
+            "Stund: 220930\n"
+            "Ställe: 33VXF 56007 96107\n"
+            "Styrka: 2\n"
+            "Slag: Personbil\n"
+            "Sysselsättning: Spanar\n"
+            "Symbol: Svart\n"
+            "Sagesman: AQ\n"
+        )
+
+        fields = parse_7s_report(text)
+
+        self.assertNotIn("sedan", fields)
 
     def test_parse_7s_report_missing_required_raises(self):
         text = "7S RAPPORT\nTill: A\n"
@@ -96,6 +128,9 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("typ: 7S-rapport", content)
         self.assertIn('tnr: "221520"', content)
         self.assertIn('tidpunkt: "2026-06-22T15:20:00"', content)
+        self.assertIn('signal_tidpunkt: "2026-06-22T19:31:09"', content)
+        self.assertIn('signal_avsandare_nummer: "+46701234567"', content)
+        self.assertIn('signal_avsandare_id: "dd1bac1d-b955-4ac0-9d53-14053c4fe69f"', content)
         self.assertIn('plats: "Långkärrsvägen"', content)
         self.assertIn("lat: 59.49063", content)
         self.assertIn("lon: 17.46740", content)
@@ -105,6 +140,7 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("**Stund:** 2026-06-22 15:20", content)
         self.assertIn("**Ställe:** Långkärrsvägen", content)
         self.assertIn("**Symbol:** [[ABC123]] och [[logotyp-fragment DGE]]", content)
+        self.assertIn("**Sedan:** Återgår till bas", content)
         self.assertNotIn("# 7S RAPPORT", content)
         self.assertNotIn("## Metadata", content)
 
@@ -178,6 +214,7 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn('tnr: "221035"', content)
         self.assertIn("**TNR:** 221035", content)
         self.assertIn('tidpunkt: "2026-06-22T10:34:00"', content)
+        self.assertIn('signal_tidpunkt: "2026-06-22T19:31:09"', content)
         self.assertIn("**Stund:** 2026-06-22 10:34", content)
 
     @patch("oden.pipelines.seven_s.get_app_state")
@@ -203,3 +240,24 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("non-canonical", "\n".join(captured_logs.output))
         self.assertIn("sagesman: 2A GRUPP", content)
         self.assertIn("**Sagesman:** 2A GRUPP", content)
+
+    @patch("oden.pipelines.seven_s.get_app_state")
+    async def test_run_omits_optional_sedan_when_missing(self, mock_get_app_state):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
+            pipeline = SevenSPipeline()
+            handled = await pipeline.run(
+                msg_data=_make_msg_data(sedan=None),
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "7s-test" / "TNR221520.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertNotIn("**Sedan:**", content)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -460,7 +460,15 @@ class TestMessageObservabilityAPI(AioHTTPTestCase):
     async def get_application(self):
         return create_app(setup_mode=False)
 
-    def _create_message(self, db_path: Path, *, status: str, group_id: str = "g-1", group_name: str = "Group 1") -> int:
+    def _create_message(
+        self,
+        db_path: Path,
+        *,
+        status: str,
+        group_id: str = "g-1",
+        group_name: str = "Group 1",
+        message_body: str | None = "hello",
+    ) -> int:
         from oden.messages_db import create_raw_message, update_message_status
 
         msg = {
@@ -469,7 +477,7 @@ class TestMessageObservabilityAPI(AioHTTPTestCase):
                 "sourceName": "Test Name",
                 "timestamp": 1710000000000,
                 "dataMessage": {
-                    "message": "hello",
+                    "message": message_body,
                     "groupV2": {
                         "id": group_id,
                         "name": group_name,
@@ -497,6 +505,25 @@ class TestMessageObservabilityAPI(AioHTTPTestCase):
             payload = await resp.json()
             self.assertEqual(payload["count"], 1)
             self.assertEqual(payload["messages"][0]["status"], "processed")
+
+    async def test_messages_list_can_hide_messages_without_content(self):
+        from oden.config_db import init_db
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "config.db"
+            init_db(db_path)
+            self._create_message(db_path, status="processed", message_body="hello")
+            self._create_message(db_path, status="processed", message_body="   ")
+            self._create_message(db_path, status="processed", message_body=None)
+
+            with unittest.mock.patch("oden.web_handlers.message_handlers.cfg.CONFIG_DB", db_path):
+                resp = await self.client.get("/api/messages?status=processed&has_content=1")
+
+            self.assertEqual(resp.status, 200)
+            payload = await resp.json()
+            self.assertEqual(payload["count"], 1)
+            self.assertTrue(payload["has_content_only"])
+            self.assertEqual(payload["messages"][0]["message_body"], "hello")
 
     async def test_message_detail_includes_runs_and_events(self):
         from oden.config_db import init_db


### PR DESCRIPTION
## Summary
- allow 7S TNR and Stund to differ, preserving TNR while using Stund as observation time
- downgrade non-canonical Sagesman to a warning and persist it as a pipeline_warning event visible in message details
- add a message-list filter to hide messages without content, backed by an API filter
- update tests and 7S documentation/schema to match the new behavior

## Verification
- ./.venv/bin/pytest

## Notes
- message detail now renders warning event text so soft-fail pipeline signals are visible in the dashboard
- the new message filter is enabled by default in the UI and can be toggled off when needed