### PR TITLE
fix: avoid Windows crash when mgrs native lib is unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,6 +409,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      - name: Set up Python for screenshots
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install screenshot dependencies
+        continue-on-error: true
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest playwright
+          python -m playwright install --with-deps chromium
+
+      - name: Generate release screenshots
+        continue-on-error: true
+        run: |
+          pytest -q tests/test_web_screenshots.py -k "test_dashboard_screenshot or test_setup_page_screenshot"
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v8
         with:
@@ -459,6 +477,19 @@ jobs:
           if [ -d artifacts/oden-windows-installer ]; then
             find artifacts/oden-windows-installer -name "*.exe" -exec cp {} release_files/ \;
           fi
+
+          # Use freshly generated screenshots when available; otherwise fall back to repo images
+          if [ -f screenshots/dashboard.png ]; then
+            cp screenshots/dashboard.png release_files/release-dashboard.png
+          else
+            cp images/dashboard.png release_files/release-dashboard.png
+          fi
+
+          if [ -f screenshots/setup.png ]; then
+            cp screenshots/setup.png release_files/release-setup.png
+          else
+            cp images/setup.png release_files/release-setup.png
+          fi
           
           # Create source package for developers
           mkdir -p source_package
@@ -506,7 +537,7 @@ jobs:
           VERSION=${{ steps.version.outputs.VERSION }}
           TAG="snapshot-$(echo '${{ github.sha }}' | cut -c1-7)"
           REPO="${{ github.repository }}"
-          SCREENSHOTS_BASE="https://raw.githubusercontent.com/${REPO}/main/images"
+          SCREENSHOTS_BASE="https://github.com/${REPO}/releases/download/${TAG}"
           cat > /tmp/snapshot_notes.md << EOF
           ## ⚠️ Snapshot Build
 
@@ -521,10 +552,10 @@ jobs:
           ## Screenshots
 
           ### Dashboard
-          ![Dashboard](${SCREENSHOTS_BASE}/dashboard.png)
+          ![Dashboard](${SCREENSHOTS_BASE}/release-dashboard.png)
 
           ### Setup Wizard
-          ![Setup](${SCREENSHOTS_BASE}/setup.png)
+          ![Setup](${SCREENSHOTS_BASE}/release-setup.png)
           EOF
 
           gh release create "$TAG" \
@@ -556,6 +587,7 @@ jobs:
           SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
           TAG="pr-${PR_NUMBER}-snapshot-${SHORT_SHA}"
           REPO="${{ github.repository }}"
+          SCREENSHOTS_BASE="https://github.com/${REPO}/releases/download/${TAG}"
 
           cat > /tmp/pr_snapshot_notes.md << EOF
           ## PR Snapshot Build
@@ -567,6 +599,14 @@ jobs:
           **Version:** ${VERSION}
 
           This pre-release is for PR validation/testing and may be replaced by newer PR snapshots.
+
+          ## Screenshots
+
+          ### Dashboard
+          ![Dashboard](${SCREENSHOTS_BASE}/release-dashboard.png)
+
+          ### Setup Wizard
+          ![Setup](${SCREENSHOTS_BASE}/release-setup.png)
           EOF
 
           gh release create "$TAG" \
@@ -621,9 +661,9 @@ jobs:
             ## Screenshots
             
             ### Dashboard
-            ![Dashboard](https://raw.githubusercontent.com/${{ github.repository }}/main/images/dashboard.png)
+            ![Dashboard](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/release-dashboard.png)
             
             ### Setup Wizard
-            ![Setup](https://raw.githubusercontent.com/${{ github.repository }}/main/images/setup.png)
+            ![Setup](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/release-setup.png)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,0 +1,201 @@
+# Database
+
+Oden uses a single SQLite file: `{oden_home}/config.db` (default `~/.oden/config.db`).
+
+All tables live in this one file. Schema is created and migrated at startup by `config_db.init_db()`.
+
+## Schema version
+
+Tracked in the `metadata` table under key `schema_version`. Current version: **5**.
+Migrations are additive-only and never downgrade.
+
+---
+
+## Tables
+
+### `metadata`
+Internal key/value store for schema housekeeping.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `key` | TEXT PK | e.g. `schema_version` |
+| `value` | TEXT | |
+
+---
+
+### `config`
+All user-configurable settings. One row per key.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `key` | TEXT PK | Setting name (see below) |
+| `value` | TEXT | Serialized value |
+| `type` | TEXT | `str`, `int`, `bool`, or `json` |
+
+Boolean values are stored as `"true"`/`"false"`. JSON values (lists, dicts) are stored as JSON strings.
+Reads fall back to `DEFAULT_CONFIG` in [config_db.py](../oden/config_db.py) when a key is absent.
+
+**Known keys** (from `DEFAULT_CONFIG` / `TYPE_MAP`):
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `vault_path` | str | `~/oden-vault` | Where markdown reports are written |
+| `signal_number` | str | — | The Signal account number |
+| `display_name` | str | `oden` | Display name for outgoing messages |
+| `signal_cli_path` | str | — | Path to signal-cli binary |
+| `signal_cli_host` | str | `127.0.0.1` | |
+| `signal_cli_port` | int | `7583` | |
+| `signal_cli_log_file` | str | — | |
+| `diagnostic_mode` | bool | `false` | |
+| `unmanaged_signal_cli` | bool | `false` | Don't start/stop signal-cli |
+| `timezone` | str | `Europe/Stockholm` | |
+| `append_window_minutes` | int | `30` | Reply window for appending to existing report |
+| `startup_message` | str | `self` | Who gets the startup notification |
+| `ignored_groups` | json | `[]` | Group IDs to silently drop |
+| `whitelist_groups` | json | `[]` | If non-empty, only process these groups |
+| `filename_format` | str | `classic` | |
+| `log_level` | str | `INFO` | |
+| `log_file` | str | — | Platform default if unset |
+| `web_enabled` | bool | `true` | |
+| `web_port` | int | `8080` | |
+| `web_access_log` | str | — | |
+| `auto_reaction_enabled` | bool | `false` | Send emoji reaction on receipt |
+| `auto_reaction_emoji` | str | `✅` | |
+| `auto_read_receipt_enabled` | bool | `false` | |
+| `db_first_enabled` | bool | `true` | Persist raw messages before processing |
+| `enabled_pipelines` | json | see source | Ordered list of active pipeline names |
+| `pipeline_settings` | json | see source | Per-pipeline config dict |
+| `raw_message_retention_days` | int | `30` | Automatic cleanup window |
+| `signal_typing_indicators` | bool | `false` | |
+| `signal_link_previews` | bool | `false` | |
+| `signal_unidentified_delivery_indicators` | bool | `false` | |
+| `regex_patterns` | json | see source | Named regex patterns used by pipelines |
+| `report_template` | str | — | Jinja2 template for new reports |
+| `append_template` | str | — | Jinja2 template for appended entries |
+
+---
+
+### `responses`
+Auto-reply templates triggered by keyword commands (e.g. `#help`, `#ok`).
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `keywords` | TEXT | JSON array of lowercase strings |
+| `body` | TEXT | Markdown reply body |
+
+Lookup uses `json_each` for case-insensitive keyword matching.
+Seeded with `help`/`hjälp` and `ok` defaults on first migration.
+
+---
+
+### `groups`
+Signal group cache — populated from `listGroups` calls, survives restarts.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `group_id` | TEXT | Signal group ID (base64) |
+| `account` | TEXT | Signal account number |
+| `name` | TEXT | Display name |
+| `member_count` | INTEGER | Last known member count |
+| `is_member` | INTEGER | `1` = still a member |
+| `last_seen` | TEXT | ISO-8601 UTC timestamp of last upsert |
+
+Primary key: `(group_id, account)` — supports multi-account setups.
+
+---
+
+### `raw_messages`
+*(Added in schema v5 — requires `db_first_enabled = true`)*
+
+Every incoming Signal envelope stored verbatim before pipeline processing.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK AUTOINCREMENT | `message_id` used by downstream tables |
+| `account` | TEXT | Signal account number |
+| `timestamp_utc` | TEXT | ISO-8601 UTC from Signal envelope |
+| `envelope_raw` | TEXT | Full JSON envelope blob |
+| `source_number` | TEXT | Sender's phone number |
+| `source_name` | TEXT | Sender's display name |
+| `group_id` | TEXT | Signal group ID (nullable for DMs) |
+| `group_name` | TEXT | Group display name at time of receipt |
+| `message_body` | TEXT | Plain text extracted from `dataMessage` |
+| `has_attachments` | INTEGER | `1` if attachments present |
+| `status` | TEXT | See lifecycle below |
+| `status_timestamp` | TEXT | ISO-8601 UTC of last status change |
+| `created_at` | TEXT | ISO-8601 UTC, default `strftime(…,'now')` |
+
+**Status lifecycle:** `received` → `queued` → `processing` → `processed` | `failed` | `ignored`
+
+**Indexes:**
+- `idx_raw_messages_account_ts` on `(account, timestamp_utc DESC)`
+- `idx_raw_messages_status` on `(status)`
+
+Cleaned up by `retention_db.cleanup_old_data()` based on `raw_message_retention_days`.
+
+---
+
+### `pipeline_runs`
+One row per (message, pipeline) execution attempt.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK AUTOINCREMENT | `run_id` |
+| `message_id` | INTEGER FK → `raw_messages.id` | Cascade delete |
+| `pipeline_name` | TEXT | e.g. `seven_s`, `group_filter` |
+| `status` | TEXT | See lifecycle below |
+| `started_at` | TEXT | ISO-8601 UTC |
+| `completed_at` | TEXT | ISO-8601 UTC |
+| `output_file` | TEXT | Path to generated vault file (if any) |
+| `error_code` | TEXT | Short error class on failure |
+| `error_message` | TEXT | Human-readable error detail |
+
+**Status lifecycle:** `pending` → `running` → `done` | `failed` | `skipped`
+
+`skipped` means the message did not match this pipeline's filter — not an error.
+
+**Indexes:**
+- `idx_pipeline_runs_message_id` on `(message_id)`
+- `idx_pipeline_runs_status` on `(pipeline_name, status)`
+
+---
+
+### `pipeline_events`
+Structured event log per pipeline run — append-only.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `run_id` | INTEGER FK → `pipeline_runs.id` | Cascade delete |
+| `event_type` | TEXT | e.g. `match`, `write`, `error` |
+| `occurred_at` | TEXT | ISO-8601 UTC, default `strftime(…,'now')` |
+| `details` | TEXT | JSON blob (nullable) |
+
+**Index:** `idx_pipeline_events_run_id` on `(run_id)`
+
+---
+
+## Retention
+
+`retention_db.cleanup_old_data(db_path, retention_days)` runs on a schedule and deletes:
+
+1. `pipeline_events` older than the cutoff (by `occurred_at`)
+2. `pipeline_events` whose parent `pipeline_run` belongs to an old `raw_message`
+3. `pipeline_runs` whose `raw_message` is older than the cutoff
+4. `raw_messages` older than the cutoff (by `created_at`)
+
+`config`, `metadata`, `responses`, and `groups` are never cleaned up by retention.
+
+---
+
+## Source files
+
+| File | Responsibility |
+|------|---------------|
+| [oden/config_db.py](../oden/config_db.py) | Schema init, migrations, config CRUD |
+| [oden/messages_db.py](../oden/messages_db.py) | `raw_messages` CRUD |
+| [oden/pipelines_db.py](../oden/pipelines_db.py) | `pipeline_runs` and `pipeline_events` CRUD |
+| [oden/groups_db.py](../oden/groups_db.py) | `groups` CRUD |
+| [oden/responses_db.py](../oden/responses_db.py) | `responses` CRUD |
+| [oden/retention_db.py](../oden/retention_db.py) | Time-based cleanup |

--- a/oden/dependency_diagnostics.py
+++ b/oden/dependency_diagnostics.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from oden.bundle_utils import get_bundled_java_path, is_bundled
 from oden.signal_manager import find_signal_cli_executable
@@ -40,6 +41,24 @@ def _classify_native_load_error(exc: Exception) -> tuple[str, str]:
         return "missing_file", "native file missing, blocked, or not bundled"
 
     return "unknown", "unknown native loader failure"
+
+
+@lru_cache(maxsize=1)
+def _get_mgrs_converter() -> Any | None:
+    """Return an MGRS->LatLon converter, or None if mgrs is unavailable."""
+    try:
+        import mgrs as mgrs_module
+
+        return mgrs_module.MGRS().toLatLon
+    except Exception as exc:
+        reason, hint = _classify_native_load_error(exc)
+        logger.warning(
+            "Dependency check: mgrs unavailable (%s: %s). Original error: %s",
+            reason,
+            hint,
+            exc,
+        )
+        return None
 
 
 def _diagnose_java() -> None:
@@ -91,18 +110,8 @@ def _diagnose_signal_cli() -> None:
 
 
 def _diagnose_mgrs() -> None:
-    try:
-        mgrs_module = importlib.import_module("mgrs")
-        _ = mgrs_module.MGRS().toLatLon
+    if _get_mgrs_converter() is not None:
         logger.info("Dependency check: mgrs native module loaded")
-    except Exception as exc:
-        reason, hint = _classify_native_load_error(exc)
-        logger.warning(
-            "Dependency check: mgrs unavailable (%s: %s). Original error: %s",
-            reason,
-            hint,
-            exc,
-        )
 
 
 def _diagnose_optional_ui_deps() -> None:

--- a/oden/dependency_diagnostics.py
+++ b/oden/dependency_diagnostics.py
@@ -1,0 +1,134 @@
+"""Cross-platform startup diagnostics for external runtime dependencies."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import platform
+import shutil
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+from oden.bundle_utils import get_bundled_java_path, is_bundled
+from oden.signal_manager import find_signal_cli_executable
+
+logger = logging.getLogger(__name__)
+
+
+def _classify_native_load_error(exc: Exception) -> tuple[str, str]:
+    text = str(exc).lower()
+    if (
+        "%1 is not a valid win32 application" in text
+        or "not a valid win32 application" in text
+        or "wrong architecture" in text
+        or "bad cpu type" in text
+    ):
+        return "wrong_arch", "architecture mismatch between runtime and native dependency"
+
+    if "vcruntime" in text or "msvcp" in text or "api-ms-win-crt" in text:
+        return "missing_vc_runtime", "missing Microsoft Visual C++ Redistributable"
+
+    if (
+        "unable to load" in text
+        or "no such file or directory" in text
+        or "cannot open shared object file" in text
+        or "image not found" in text
+        or "the specified module could not be found" in text
+    ):
+        return "missing_file", "native file missing, blocked, or not bundled"
+
+    return "unknown", "unknown native loader failure"
+
+
+def _diagnose_java() -> None:
+    bundled_java = get_bundled_java_path()
+    if bundled_java:
+        java_path = Path(bundled_java)
+        if sys.platform == "win32" and java_path.suffix.lower() != ".exe":
+            logger.warning(
+                "Dependency check: Java executable mismatch (%s); expected .exe on Windows",
+                bundled_java,
+            )
+            return
+
+        logger.info("Dependency check: Java available (bundled) at %s", bundled_java)
+        return
+
+    system_java = shutil.which("java")
+    if system_java:
+        logger.info("Dependency check: Java available (system PATH) at %s", system_java)
+    else:
+        logger.warning("Dependency check: Java not found (bundled missing and PATH lookup failed)")
+
+
+def _diagnose_signal_cli() -> None:
+    try:
+        executable = find_signal_cli_executable()
+    except FileNotFoundError:
+        logger.warning("Dependency check: signal-cli executable not found")
+        return
+    except Exception as exc:
+        logger.warning("Dependency check: signal-cli probe failed: %s", exc)
+        return
+
+    path = Path(executable)
+    if not path.exists():
+        logger.warning("Dependency check: signal-cli path does not exist: %s", executable)
+        return
+
+    if sys.platform == "win32":
+        ext = path.suffix.lower()
+        executable_like = ext in {".bat", ".cmd", ".exe"} or os.access(path, os.X_OK)
+    else:
+        executable_like = os.access(path, os.X_OK)
+
+    if executable_like:
+        logger.info("Dependency check: signal-cli executable available at %s", executable)
+    else:
+        logger.warning("Dependency check: signal-cli exists but is not executable: %s", executable)
+
+
+def _diagnose_mgrs() -> None:
+    try:
+        mgrs_module = importlib.import_module("mgrs")
+        _ = mgrs_module.MGRS().toLatLon
+        logger.info("Dependency check: mgrs native module loaded")
+    except Exception as exc:
+        reason, hint = _classify_native_load_error(exc)
+        logger.warning(
+            "Dependency check: mgrs unavailable (%s: %s). Original error: %s",
+            reason,
+            hint,
+            exc,
+        )
+
+
+def _diagnose_optional_ui_deps() -> None:
+    missing: list[str] = []
+    for mod_name in ("pystray", "PIL"):
+        try:
+            importlib.import_module(mod_name)
+        except Exception:
+            missing.append(mod_name)
+
+    if missing:
+        logger.info("Dependency check: optional tray deps missing (%s); tray icon may be disabled", ", ".join(missing))
+    else:
+        logger.info("Dependency check: optional tray deps available (pystray, PIL)")
+
+
+@lru_cache(maxsize=1)
+def run_startup_dependency_diagnostics() -> None:
+    """Log a one-time dependency diagnostics summary for current runtime."""
+    logger.info(
+        "Dependency diagnostics: platform=%s arch=%s bundled=%s",
+        platform.system(),
+        platform.machine(),
+        is_bundled(),
+    )
+    _diagnose_java()
+    _diagnose_signal_cli()
+    _diagnose_mgrs()
+    _diagnose_optional_ui_deps()

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 import logging
 import re
+from functools import lru_cache
 from typing import Any
-
-import mgrs
 
 from oden.link_formatter import apply_regex_links
 from oden.pipelines.structured_report import (
@@ -64,6 +63,31 @@ _FULL_PLATE_RE = re.compile(rf"\b([{_PLATE_ALPHABET}]{{3}}[0-9]{{2}}[0-9{_PLATE_
 _PARTIAL_PLATE_RE = re.compile(r"\b(?=[A-Z0-9.]*\.)([A-Z.]{3}[0-9.]{2}[0-9A-Z.])\b", re.IGNORECASE)
 
 
+@lru_cache(maxsize=1)
+def _get_mgrs_converter() -> Any | None:
+    """Return an MGRS->LatLon converter or None when mgrs is unavailable."""
+    try:
+        import mgrs as mgrs_module
+
+        return mgrs_module.MGRS().toLatLon
+    except Exception as exc:
+        logger.warning("MGRS conversion unavailable; continuing without coordinates (%s)", exc)
+        return None
+
+
+def _mgrs_to_latlon(mgrs_str: str) -> tuple[float, float] | None:
+    converter = _get_mgrs_converter()
+    if converter is None:
+        return None
+
+    try:
+        lat, lon = converter(mgrs_str)
+        return float(lat), float(lon)
+    except Exception as exc:
+        logger.debug("Failed to convert MGRS %r to coordinates: %s", mgrs_str, exc)
+        return None
+
+
 def _normalize_label(label: str) -> str:
     return normalize_label(label, _LABEL_ALIASES)
 
@@ -77,14 +101,11 @@ def _extract_location(stalle: str) -> tuple[str, float | None, float | None]:
     mgrs_str = parts[0].strip()
     address = parts[1].strip() if len(parts) > 1 else ""
 
-    lat = None
-    lon = None
-    try:
-        m = mgrs.MGRS()
-        lat, lon = m.toLatLon(mgrs_str)
-    except Exception as e:
-        logging.getLogger(__name__).debug(f"Failed to convert MGRS '{mgrs_str}' to coordinates: {e}")
+    coords = _mgrs_to_latlon(mgrs_str)
+    if coords is None:
+        return stalle.strip(), None, None
 
+    lat, lon = coords
     return address or stalle.strip(), lat, lon
 
 

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
 from oden.dependency_diagnostics import _get_mgrs_converter
 from oden.link_formatter import apply_regex_links

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -63,6 +63,45 @@ _FULL_PLATE_RE = re.compile(rf"\b([{_PLATE_ALPHABET}]{{3}}[0-9]{{2}}[0-9{_PLATE_
 _PARTIAL_PLATE_RE = re.compile(r"\b(?=[A-Z0-9.]*\.)([A-Z.]{3}[0-9.]{2}[0-9A-Z.])\b", re.IGNORECASE)
 
 
+def _classify_mgrs_load_error(exc: Exception) -> tuple[str, str]:
+    """Classify likely root cause when mgrs native loading fails."""
+    text = str(exc).lower()
+
+    if (
+        "%1 is not a valid win32 application" in text
+        or "not a valid win32 application" in text
+        or "wrong architecture" in text
+        or "bad cpu type" in text
+    ):
+        return (
+            "wrong_arch",
+            "Binary architecture mismatch between Oden, Python runtime, and libmgrs.",
+        )
+
+    if "vcruntime" in text or "msvcp" in text or "api-ms-win-crt" in text:
+        return (
+            "missing_vc_runtime",
+            "Microsoft Visual C++ Redistributable (2015-2022) is likely missing.",
+        )
+
+    if (
+        "unable to load libmgrs" in text
+        or "no such file or directory" in text
+        or "cannot open shared object file" in text
+        or "image not found" in text
+        or "the specified module could not be found" in text
+    ):
+        return (
+            "missing_file",
+            "libmgrs native files are missing, blocked, or not bundled in the app image.",
+        )
+
+    return (
+        "unknown",
+        "Unknown native-load issue; verify bundled files, VC runtime, and architecture alignment.",
+    )
+
+
 @lru_cache(maxsize=1)
 def _get_mgrs_converter() -> Any | None:
     """Return an MGRS->LatLon converter or None when mgrs is unavailable."""
@@ -71,7 +110,13 @@ def _get_mgrs_converter() -> Any | None:
 
         return mgrs_module.MGRS().toLatLon
     except Exception as exc:
-        logger.warning("MGRS conversion unavailable; continuing without coordinates (%s)", exc)
+        reason, hint = _classify_mgrs_load_error(exc)
+        logger.warning(
+            "MGRS conversion unavailable (%s); %s Original error: %s",
+            reason,
+            hint,
+            exc,
+        )
         return None
 
 
@@ -156,6 +201,11 @@ class SevenSPipeline(StructuredReportPipeline):
     header_prefixes = ("7S RAPPORT",)
     report_id_prefix = "7S"
     report_type = "7S-rapport"
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Run one early self-check so startup logs contain actionable diagnostics.
+        _get_mgrs_converter()
 
     def parse_report(self, message_text: str) -> dict[str, str]:
         return parse_7s_report(message_text)

--- a/oden/pipelines/seven_s.py
+++ b/oden/pipelines/seven_s.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 import logging
 import re
-from functools import lru_cache
-from typing import Any
 
+from oden.dependency_diagnostics import _get_mgrs_converter
 from oden.link_formatter import apply_regex_links
 from oden.pipelines.structured_report import (
     StructuredReportContext,
@@ -61,63 +60,6 @@ _LABEL_ALIASES = {
 _PLATE_ALPHABET = "ABCDEFGHJKLMNPRSTUWXYZ"
 _FULL_PLATE_RE = re.compile(rf"\b([{_PLATE_ALPHABET}]{{3}}[0-9]{{2}}[0-9{_PLATE_ALPHABET}])\b", re.IGNORECASE)
 _PARTIAL_PLATE_RE = re.compile(r"\b(?=[A-Z0-9.]*\.)([A-Z.]{3}[0-9.]{2}[0-9A-Z.])\b", re.IGNORECASE)
-
-
-def _classify_mgrs_load_error(exc: Exception) -> tuple[str, str]:
-    """Classify likely root cause when mgrs native loading fails."""
-    text = str(exc).lower()
-
-    if (
-        "%1 is not a valid win32 application" in text
-        or "not a valid win32 application" in text
-        or "wrong architecture" in text
-        or "bad cpu type" in text
-    ):
-        return (
-            "wrong_arch",
-            "Binary architecture mismatch between Oden, Python runtime, and libmgrs.",
-        )
-
-    if "vcruntime" in text or "msvcp" in text or "api-ms-win-crt" in text:
-        return (
-            "missing_vc_runtime",
-            "Microsoft Visual C++ Redistributable (2015-2022) is likely missing.",
-        )
-
-    if (
-        "unable to load libmgrs" in text
-        or "no such file or directory" in text
-        or "cannot open shared object file" in text
-        or "image not found" in text
-        or "the specified module could not be found" in text
-    ):
-        return (
-            "missing_file",
-            "libmgrs native files are missing, blocked, or not bundled in the app image.",
-        )
-
-    return (
-        "unknown",
-        "Unknown native-load issue; verify bundled files, VC runtime, and architecture alignment.",
-    )
-
-
-@lru_cache(maxsize=1)
-def _get_mgrs_converter() -> Any | None:
-    """Return an MGRS->LatLon converter or None when mgrs is unavailable."""
-    try:
-        import mgrs as mgrs_module
-
-        return mgrs_module.MGRS().toLatLon
-    except Exception as exc:
-        reason, hint = _classify_mgrs_load_error(exc)
-        logger.warning(
-            "MGRS conversion unavailable (%s); %s Original error: %s",
-            reason,
-            hint,
-            exc,
-        )
-        return None
 
 
 def _mgrs_to_latlon(mgrs_str: str) -> tuple[float, float] | None:
@@ -201,11 +143,6 @@ class SevenSPipeline(StructuredReportPipeline):
     header_prefixes = ("7S RAPPORT",)
     report_id_prefix = "7S"
     report_type = "7S-rapport"
-
-    def __init__(self) -> None:
-        super().__init__()
-        # Run one early self-check so startup logs contain actionable diagnostics.
-        _get_mgrs_converter()
 
     def parse_report(self, message_text: str) -> dict[str, str]:
         return parse_7s_report(message_text)

--- a/oden/s7_watcher.py
+++ b/oden/s7_watcher.py
@@ -29,6 +29,7 @@ from oden.config import (
     is_configured,
     reload_config,
 )
+from oden.dependency_diagnostics import run_startup_dependency_diagnostics
 from oden.log_utils import apply_log_level, configure_logging, write_log_level
 from oden.signal_listener import subscribe_and_listen
 from oden.signal_manager import SignalManager, is_signal_cli_running
@@ -234,6 +235,7 @@ def main() -> None:
     configure_logging()
 
     logger.info(f"Starting Oden v{__version__}...")
+    run_startup_dependency_diagnostics()
 
     # Auto-recover pointer file if missing but config.db exists at default location
     _is_configured, _config_error = is_configured()

--- a/s7_watcher.spec
+++ b/s7_watcher.spec
@@ -61,8 +61,9 @@ _mgrs_binaries = []
 _mgrs_spec = importlib.util.find_spec('mgrs')
 if _mgrs_spec and _mgrs_spec.origin:
     _site_pkgs = os.path.dirname(os.path.dirname(_mgrs_spec.origin))
-    for _lib in glob.glob(os.path.join(_site_pkgs, 'libmgrs*.so')):
-        _mgrs_binaries.append((_lib, '.'))
+    for _pattern in ('libmgrs*.so', 'libmgrs*.dylib', 'libmgrs*.pyd', 'libmgrs*.dll'):
+        for _lib in glob.glob(os.path.join(_site_pkgs, _pattern)):
+            _mgrs_binaries.append((_lib, '.'))
 
 a = Analysis(
     ['oden/s7_watcher.py'],

--- a/scripts/oden.iss
+++ b/scripts/oden.iss
@@ -100,12 +100,12 @@ begin
 	begin
 		OdenHome := GetOdenHomeFromPointer();
 		if OdenHome = '' then
-			OdenHome := ExpandConstant('{userprofile}\.oden');
+			OdenHome := ExpandConstant('{%USERPROFILE}\.oden');
 
 		DeleteDirectoryIfSafe(OdenHome);
 		DeleteDirectoryIfSafe(ExpandConstant('{userappdata}\Oden'));
 		DeleteDirectoryIfSafe(ExpandConstant('{localappdata}\Oden'));
 		DeleteDirectoryIfSafe(ExpandConstant('{localappdata}\signal-cli'));
-		DeleteDirectoryIfSafe(ExpandConstant('{userprofile}\.local\share\signal-cli'));
+		DeleteDirectoryIfSafe(ExpandConstant('{%USERPROFILE}\.local\share\signal-cli'));
 	end;
 end;

--- a/scripts/oden.iss
+++ b/scripts/oden.iss
@@ -34,3 +34,78 @@ Name: "{userstartup}\Oden"; Filename: "{app}\Oden.exe"; Tasks: startup
 
 [Run]
 Filename: "{app}\Oden.exe"; Description: "Launch Oden"; Flags: nowait postinstall skipifsilent
+
+[Code]
+var
+	RemoveAllUserData: Boolean;
+
+function GetOdenHomeFromPointer(): string;
+var
+	PointerPath: string;
+	Content: string;
+begin
+	Result := '';
+	PointerPath := ExpandConstant('{userappdata}\Oden\oden_home.txt');
+
+	if LoadStringFromFile(PointerPath, Content) then
+	begin
+		Content := Trim(Content);
+		if Content <> '' then
+			Result := RemoveBackslashUnlessRoot(Content);
+	end;
+end;
+
+function IsSafeDirectoryToDelete(const DirPath: string): Boolean;
+var
+	Normalized: string;
+begin
+	Normalized := RemoveBackslashUnlessRoot(Trim(DirPath));
+
+	if (Normalized = '') or (Normalized = '\\') or (Length(Normalized) <= 3) then
+	begin
+		Result := False;
+		exit;
+	end;
+
+	Result := DirExists(Normalized);
+end;
+
+procedure DeleteDirectoryIfSafe(const DirPath: string);
+begin
+	if IsSafeDirectoryToDelete(DirPath) then
+	begin
+		if DelTree(DirPath, True, True, True) then
+			Log(Format('Removed user data directory: %s', [DirPath]))
+		else
+			Log(Format('Failed to remove user data directory: %s', [DirPath]));
+	end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+	OdenHome: string;
+begin
+	if CurUninstallStep = usUninstall then
+	begin
+		RemoveAllUserData :=
+			MsgBox(
+				'Also remove all Oden user data?' + #13#10 + #13#10 +
+				'This deletes config.db, signal-data, logs, and signal-cli local data.',
+				mbConfirmation,
+				MB_YESNO or MB_DEFBUTTON2
+			) = IDYES;
+	end;
+
+	if (CurUninstallStep = usPostUninstall) and RemoveAllUserData then
+	begin
+		OdenHome := GetOdenHomeFromPointer();
+		if OdenHome = '' then
+			OdenHome := ExpandConstant('{userprofile}\.oden');
+
+		DeleteDirectoryIfSafe(OdenHome);
+		DeleteDirectoryIfSafe(ExpandConstant('{userappdata}\Oden'));
+		DeleteDirectoryIfSafe(ExpandConstant('{localappdata}\Oden'));
+		DeleteDirectoryIfSafe(ExpandConstant('{localappdata}\signal-cli'));
+		DeleteDirectoryIfSafe(ExpandConstant('{userprofile}\.local\share\signal-cli'));
+	end;
+end;

--- a/scripts/oden.iss
+++ b/scripts/oden.iss
@@ -42,7 +42,7 @@ var
 function GetOdenHomeFromPointer(): string;
 var
 	PointerPath: string;
-	Content: string;
+	Content: AnsiString;
 begin
 	Result := '';
 	PointerPath := ExpandConstant('{userappdata}\Oden\oden_home.txt');

--- a/tests/test_dependency_diagnostics.py
+++ b/tests/test_dependency_diagnostics.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from oden.dependency_diagnostics import (
     _classify_native_load_error,
@@ -18,7 +18,7 @@ class TestDependencyDiagnostics(unittest.TestCase):
         reason, hint = _classify_native_load_error(Exception("DLL load failed: VCRUNTIME140.dll"))
 
         self.assertEqual(reason, "missing_vc_runtime")
-        self.assertIn("visual", hint.lower())
+        self.assertIn("visual", hint)
 
     @patch("oden.dependency_diagnostics.platform.machine", return_value="x86_64")
     @patch("oden.dependency_diagnostics.platform.system", return_value="Windows")

--- a/tests/test_dependency_diagnostics.py
+++ b/tests/test_dependency_diagnostics.py
@@ -1,8 +1,9 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from oden.dependency_diagnostics import (
     _classify_native_load_error,
+    _get_mgrs_converter,
     run_startup_dependency_diagnostics,
 )
 
@@ -10,42 +11,17 @@ from oden.dependency_diagnostics import (
 class TestDependencyDiagnostics(unittest.TestCase):
     def setUp(self):
         run_startup_dependency_diagnostics.cache_clear()
+        _get_mgrs_converter.cache_clear()
 
     def tearDown(self):
         run_startup_dependency_diagnostics.cache_clear()
+        _get_mgrs_converter.cache_clear()
 
     def test_classify_native_load_error_missing_vc_runtime(self):
         reason, hint = _classify_native_load_error(Exception("DLL load failed: VCRUNTIME140.dll"))
 
         self.assertEqual(reason, "missing_vc_runtime")
-        self.assertIn("visual", hint)
-
-    @patch("oden.dependency_diagnostics.platform.machine", return_value="x86_64")
-    @patch("oden.dependency_diagnostics.platform.system", return_value="Windows")
-    @patch("oden.dependency_diagnostics.is_bundled", return_value=True)
-    @patch("oden.dependency_diagnostics._diagnose_optional_ui_deps")
-    @patch("oden.dependency_diagnostics._diagnose_mgrs")
-    @patch("oden.dependency_diagnostics._diagnose_signal_cli")
-    @patch("oden.dependency_diagnostics._diagnose_java")
-    @patch("oden.dependency_diagnostics.logger")
-    def test_run_startup_dependency_diagnostics_invokes_all_checks_once(
-        self,
-        mock_logger,
-        mock_java,
-        mock_signal_cli,
-        mock_mgrs,
-        mock_ui,
-        _mock_is_bundled,
-        _mock_system,
-        _mock_machine,
-    ):
-        run_startup_dependency_diagnostics()
-
-        mock_logger.info.assert_called_once()
-        mock_java.assert_called_once_with()
-        mock_signal_cli.assert_called_once_with()
-        mock_mgrs.assert_called_once_with()
-        mock_ui.assert_called_once_with()
+        self.assertIn("visual", hint.lower())
 
     @patch("oden.dependency_diagnostics._diagnose_optional_ui_deps")
     @patch("oden.dependency_diagnostics._diagnose_mgrs")
@@ -87,12 +63,11 @@ class TestDependencyDiagnostics(unittest.TestCase):
         warning_calls = [args[0] for args, _ in mock_logger.warning.call_args_list]
         self.assertTrue(any("not executable" in call for call in warning_calls))
 
-    @patch("oden.dependency_diagnostics.importlib.import_module", side_effect=Exception("Unable to load libmgrs"))
+    @patch("oden.dependency_diagnostics._get_mgrs_converter", return_value=None)
     @patch("oden.dependency_diagnostics.logger")
-    def test_diagnose_mgrs_logs_classified_warning(self, mock_logger, _mock_import):
+    def test_diagnose_mgrs_skips_success_log_when_unavailable(self, mock_logger, _):
         from oden.dependency_diagnostics import _diagnose_mgrs
 
         _diagnose_mgrs()
 
-        warning_calls = [args[0] for args, _ in mock_logger.warning.call_args_list]
-        self.assertTrue(any("mgrs unavailable" in call for call in warning_calls))
+        mock_logger.info.assert_not_called()

--- a/tests/test_dependency_diagnostics.py
+++ b/tests/test_dependency_diagnostics.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import patch
+
+from oden.dependency_diagnostics import (
+    _classify_native_load_error,
+    run_startup_dependency_diagnostics,
+)
+
+
+class TestDependencyDiagnostics(unittest.TestCase):
+    def setUp(self):
+        run_startup_dependency_diagnostics.cache_clear()
+
+    def tearDown(self):
+        run_startup_dependency_diagnostics.cache_clear()
+
+    def test_classify_native_load_error_missing_vc_runtime(self):
+        reason, hint = _classify_native_load_error(Exception("DLL load failed: VCRUNTIME140.dll"))
+
+        self.assertEqual(reason, "missing_vc_runtime")
+        self.assertIn("visual", hint.lower())
+
+    @patch("oden.dependency_diagnostics.platform.machine", return_value="x86_64")
+    @patch("oden.dependency_diagnostics.platform.system", return_value="Windows")
+    @patch("oden.dependency_diagnostics.is_bundled", return_value=True)
+    @patch("oden.dependency_diagnostics._diagnose_optional_ui_deps")
+    @patch("oden.dependency_diagnostics._diagnose_mgrs")
+    @patch("oden.dependency_diagnostics._diagnose_signal_cli")
+    @patch("oden.dependency_diagnostics._diagnose_java")
+    @patch("oden.dependency_diagnostics.logger")
+    def test_run_startup_dependency_diagnostics_invokes_all_checks_once(
+        self,
+        mock_logger,
+        mock_java,
+        mock_signal_cli,
+        mock_mgrs,
+        mock_ui,
+        _mock_is_bundled,
+        _mock_system,
+        _mock_machine,
+    ):
+        run_startup_dependency_diagnostics()
+
+        mock_logger.info.assert_called_once()
+        mock_java.assert_called_once_with()
+        mock_signal_cli.assert_called_once_with()
+        mock_mgrs.assert_called_once_with()
+        mock_ui.assert_called_once_with()
+
+    @patch("oden.dependency_diagnostics._diagnose_optional_ui_deps")
+    @patch("oden.dependency_diagnostics._diagnose_mgrs")
+    @patch("oden.dependency_diagnostics._diagnose_signal_cli")
+    @patch("oden.dependency_diagnostics._diagnose_java")
+    @patch("oden.dependency_diagnostics.logger")
+    def test_run_startup_dependency_diagnostics_is_cached(
+        self,
+        _mock_logger,
+        mock_java,
+        mock_signal_cli,
+        mock_mgrs,
+        mock_ui,
+    ):
+        run_startup_dependency_diagnostics()
+        run_startup_dependency_diagnostics()
+
+        self.assertEqual(mock_java.call_count, 1)
+        self.assertEqual(mock_signal_cli.call_count, 1)
+        self.assertEqual(mock_mgrs.call_count, 1)
+        self.assertEqual(mock_ui.call_count, 1)
+
+    @patch("oden.dependency_diagnostics.os.access", return_value=False)
+    @patch("oden.dependency_diagnostics.find_signal_cli_executable", return_value="/tmp/signal-cli")
+    @patch("oden.dependency_diagnostics.Path.exists", return_value=True)
+    @patch("oden.dependency_diagnostics.logger")
+    def test_diagnose_signal_cli_warns_when_not_executable(
+        self,
+        mock_logger,
+        _mock_exists,
+        _mock_find,
+        _mock_access,
+    ):
+        from oden.dependency_diagnostics import _diagnose_signal_cli
+
+        with patch("oden.dependency_diagnostics.sys.platform", "linux"):
+            _diagnose_signal_cli()
+
+        warning_calls = [args[0] for args, _ in mock_logger.warning.call_args_list]
+        self.assertTrue(any("not executable" in call for call in warning_calls))
+
+    @patch("oden.dependency_diagnostics.importlib.import_module", side_effect=Exception("Unable to load libmgrs"))
+    @patch("oden.dependency_diagnostics.logger")
+    def test_diagnose_mgrs_logs_classified_warning(self, mock_logger, _mock_import):
+        from oden.dependency_diagnostics import _diagnose_mgrs
+
+        _diagnose_mgrs()
+
+        warning_calls = [args[0] for args, _ in mock_logger.warning.call_args_list]
+        self.assertTrue(any("mgrs unavailable" in call for call in warning_calls))

--- a/tests/test_s7_watcher.py
+++ b/tests/test_s7_watcher.py
@@ -12,6 +12,7 @@ from oden.signal_manager import SignalManager, build_signal_cli_command, is_sign
 
 
 class TestS7Watcher(unittest.IsolatedAsyncioTestCase):
+    @patch("oden.s7_watcher.run_startup_dependency_diagnostics")
     @patch("oden.s7_watcher._create_tray", return_value=None)
     @patch("oden.s7_watcher.is_configured", return_value=(True, None))
     @patch("oden.config.validate_signal_number", return_value=(True, None, []))
@@ -23,7 +24,13 @@ class TestS7Watcher(unittest.IsolatedAsyncioTestCase):
     @patch("oden.s7_watcher.SIGNAL_CLI_HOST", "1.2.3.4")
     @patch("oden.s7_watcher.SIGNAL_CLI_PORT", 1234)
     def test_main_managed_success(
-        self, mock_subscribe, mock_signal_manager_class, mock_validate, mock_is_configured, mock_tray
+        self,
+        mock_subscribe,
+        mock_signal_manager_class,
+        mock_validate,
+        mock_is_configured,
+        mock_tray,
+        mock_dependency_diagnostics,
     ):
         """Tests main in managed mode with successful execution."""
         mock_manager_instance = mock_signal_manager_class.return_value
@@ -32,6 +39,7 @@ class TestS7Watcher(unittest.IsolatedAsyncioTestCase):
             s7_main()
 
         self.assertEqual(cm.exception.code, 0)
+        mock_dependency_diagnostics.assert_called_once_with()
         mock_signal_manager_class.assert_called_once_with("1.2.3.4", 1234)
         mock_manager_instance.start.assert_called_once()
         mock_subscribe.assert_called_once_with("1.2.3.4", 1234)

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 from oden import config as cfg
-from oden.pipelines.seven_s import SevenSPipeline, is_7s_message, parse_7s_report
+from oden.pipelines.seven_s import SevenSPipeline, _extract_location, is_7s_message, parse_7s_report
 
 _TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
 _SERVER_RECEIVED_TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 9, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
@@ -99,6 +99,15 @@ class TestSevenSPipelineHelpers(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_7s_report(text)
 
+    @patch("oden.pipelines.seven_s._mgrs_to_latlon", return_value=None)
+    def test_extract_location_keeps_full_stalle_when_mgrs_unavailable(self, _mock_mgrs_to_latlon):
+        stalle = "34VCM 79349 26095, Långkärrsvägen"
+        plats, lat, lon = _extract_location(stalle)
+
+        self.assertEqual(plats, stalle)
+        self.assertIsNone(lat)
+        self.assertIsNone(lon)
+
 
 class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
     @patch("oden.pipelines.structured_report.get_app_state")
@@ -144,6 +153,37 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("**Sedan:** Återgår till bas", content)
         self.assertNotIn("# 7S RAPPORT", content)
         self.assertNotIn("## Metadata", content)
+
+    @patch("oden.pipelines.structured_report.get_app_state")
+    @patch("oden.pipelines.seven_s._mgrs_to_latlon", return_value=None)
+    async def test_run_keeps_full_stalle_and_omits_coordinates_when_mgrs_unavailable(
+        self,
+        _mock_mgrs_to_latlon,
+        mock_get_app_state,
+    ):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("oden.config.VAULT_PATH", tmpdir):
+            pipeline = SevenSPipeline()
+            msg_data = _make_msg_data(stalle="34VCM 79349 26095, Långkärrsvägen")
+
+            handled = await pipeline.run(
+                msg_data=msg_data,
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "TNR221520.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn('plats: "34VCM 79349 26095, Långkärrsvägen"', content)
+        self.assertNotIn("lat:", content)
+        self.assertNotIn("lon:", content)
+        self.assertNotIn("location:", content)
 
     @patch("oden.pipelines.structured_report.get_app_state")
     async def test_run_adds_collision_suffix_to_filename_and_tnr(self, mock_get_app_state):

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 from oden import config as cfg
-from oden.pipelines.seven_s import SevenSPipeline, _extract_location, is_7s_message, parse_7s_report
+from oden.pipelines.seven_s import (
+    SevenSPipeline,
+    _classify_mgrs_load_error,
+    _extract_location,
+    is_7s_message,
+    parse_7s_report,
+)
 
 _TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 5, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
 _SERVER_RECEIVED_TIMESTAMP = int(datetime.datetime(2026, 6, 22, 19, 31, 9, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
@@ -107,6 +113,29 @@ class TestSevenSPipelineHelpers(unittest.TestCase):
         self.assertEqual(plats, stalle)
         self.assertIsNone(lat)
         self.assertIsNone(lon)
+
+    def test_classify_mgrs_load_error_missing_file(self):
+        reason, hint = _classify_mgrs_load_error(Exception("Unable to load libmgrs.cp312-win_amd64.pyd"))
+
+        self.assertEqual(reason, "missing_file")
+        self.assertIn("missing", hint.lower())
+
+    def test_classify_mgrs_load_error_missing_vc_runtime(self):
+        reason, hint = _classify_mgrs_load_error(Exception("DLL load failed while importing core: VCRUNTIME140.dll"))
+
+        self.assertEqual(reason, "missing_vc_runtime")
+        self.assertIn("visual c++", hint.lower())
+
+    def test_classify_mgrs_load_error_wrong_arch(self):
+        reason, hint = _classify_mgrs_load_error(Exception("%1 is not a valid Win32 application"))
+
+        self.assertEqual(reason, "wrong_arch")
+        self.assertIn("architecture", hint.lower())
+
+    @patch("oden.pipelines.seven_s._get_mgrs_converter")
+    def test_pipeline_init_runs_mgrs_self_check(self, mock_get_mgrs_converter):
+        SevenSPipeline()
+        mock_get_mgrs_converter.assert_called_once_with()
 
 
 class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, Mock, patch
 from oden import config as cfg
 from oden.pipelines.seven_s import (
     SevenSPipeline,
-    _classify_mgrs_load_error,
     _extract_location,
     is_7s_message,
     parse_7s_report,
@@ -113,29 +112,6 @@ class TestSevenSPipelineHelpers(unittest.TestCase):
         self.assertEqual(plats, stalle)
         self.assertIsNone(lat)
         self.assertIsNone(lon)
-
-    def test_classify_mgrs_load_error_missing_file(self):
-        reason, hint = _classify_mgrs_load_error(Exception("Unable to load libmgrs.cp312-win_amd64.pyd"))
-
-        self.assertEqual(reason, "missing_file")
-        self.assertIn("missing", hint.lower())
-
-    def test_classify_mgrs_load_error_missing_vc_runtime(self):
-        reason, hint = _classify_mgrs_load_error(Exception("DLL load failed while importing core: VCRUNTIME140.dll"))
-
-        self.assertEqual(reason, "missing_vc_runtime")
-        self.assertIn("visual c++", hint.lower())
-
-    def test_classify_mgrs_load_error_wrong_arch(self):
-        reason, hint = _classify_mgrs_load_error(Exception("%1 is not a valid Win32 application"))
-
-        self.assertEqual(reason, "wrong_arch")
-        self.assertIn("architecture", hint.lower())
-
-    @patch("oden.pipelines.seven_s._get_mgrs_converter")
-    def test_pipeline_init_runs_mgrs_self_check(self, mock_get_mgrs_converter):
-        SevenSPipeline()
-        mock_get_mgrs_converter.assert_called_once_with()
 
 
 class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- remove import-time dependency on mgrs in 7S pipeline
- lazy-load mgrs converter at runtime and continue if unavailable
- preserve full Ställe text and omit lat/lon/location when conversion cannot run
- add tests for fallback behavior

## Why
PyInstaller Windows builds could fail at startup with:
MGRSError: Unable to load libmgrs.cp312-win_amd64.pyd

This change prevents app startup from crashing while still using MGRS conversion when the native library is available.

## Validation
- pytest tests/test_seven_s_pipeline.py -q
- pytest tests/test_pipeline_orchestrator.py -q
- ruff check oden/pipelines/seven_s.py tests/test_seven_s_pipeline.py