### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-06-25
+
+### Fixed
+
+- **Windows MGRS-fallback**: Förhindrar krasch på Windows när native MGRS-bibliotek saknas genom att använda säker fallback-path i 7S-flödet
+
+### Changed
+
+- **Beroenden**: Uppdaterade flera beroenden och dev-beroenden (`mgrs`, `aiohttp`, `pytest`, `ruff`, `playwright`) samt GitHub Actions (`actions/cache`, `actions/checkout`)
+
 ## [3.1.0] - 2026-06-24
 
 ### Added


### PR DESCRIPTION
## Summary
- Prepare release notes for 3.1.1 in CHANGELOG.md

## Included in 3.1.1
- Windows MGRS fallback crash fix
- Dependency and GitHub Actions updates

## Checklist
- [x] CHANGELOG updated
- [ ] CI checks green
- [ ] Merge to main
- [ ] Tag v3.1.1 from main