### PR TITLE
feat: stöd bilder i 7s/fors/pedars

### DIFF
--- a/oden/pipelines/structured_report.py
+++ b/oden/pipelines/structured_report.py
@@ -14,7 +14,9 @@ from typing import Any
 
 from oden import config as cfg
 from oden.app_state import get_app_state
-from oden.formatting import resolve_output_dir
+from oden.attachment_handler import save_attachments
+from oden.formatting import format_sender_display, resolve_output_dir
+from oden.link_formatter import apply_regex_links
 
 _SHORT_REPORT_TIME_RE = re.compile(r"^\d{6}$")
 _LONG_REPORT_TIME_RE = re.compile(r"^(\d{2})(\d{2})(\d{2})([A-Z])([A-Z]{3})(\d{4})$")
@@ -174,7 +176,36 @@ def extract_message_details(envelope: dict[str, Any]) -> tuple[str | None, str |
         group_meta.get("name") or group_meta.get("title") or group_meta.get("groupName"),
         group_meta.get("id") or group_meta.get("groupId"),
         int(timestamp) if isinstance(timestamp, int | float) else 0,
+        dm.get("attachments") or [],
+        dm.get("quote") if isinstance(dm.get("quote"), dict) else None,
     )
+
+
+def _read_frontmatter(filepath: str) -> dict[str, str]:
+    try:
+        with open(filepath, encoding="utf-8") as handle:
+            content = handle.read(4096)
+    except OSError:
+        return {}
+
+    if not content.startswith("---\n"):
+        return {}
+
+    end = content.find("\n---", 4)
+    if end == -1:
+        return {}
+
+    values: dict[str, str] = {}
+    for raw in content[4:end].splitlines():
+        if ":" not in raw:
+            continue
+        key, value = raw.split(":", 1)
+        values[key.strip()] = value.strip().strip('"')
+    return values
+
+
+def _append_section(content: str, lines: Sequence[str]) -> str:
+    return f"{content.rstrip()}\n\n" + "\n".join(lines) + "\n"
 
 
 @dataclass(frozen=True)
@@ -253,6 +284,95 @@ class StructuredReportPipeline:
     def render_report(self, context: StructuredReportContext) -> str:
         raise NotImplementedError
 
+    def _resolve_effective_subdir(self) -> str | None:
+        pipeline_settings = cfg.PIPELINE_SETTINGS.get(self.name, {}) if isinstance(cfg.PIPELINE_SETTINGS, dict) else {}
+        configured_subdir = pipeline_settings.get("vault_subdir", self.vault_subdir)
+        enabled_override = pipeline_settings.get("vault_subdir_enabled")
+        use_subdir = enabled_override if isinstance(enabled_override, bool) else bool(configured_subdir)
+        return configured_subdir if use_subdir else None
+
+    def _find_quoted_report_file(
+        self,
+        *,
+        group_title: str,
+        quote_timestamp_ms: int,
+        effective_vault_subdir: str | None,
+    ) -> str | None:
+        signal_dt = datetime.datetime.fromtimestamp(quote_timestamp_ms / 1000, tz=cfg.TIMEZONE).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+        target_dir = resolve_output_dir(group_title, effective_vault_subdir)
+        if not os.path.isdir(target_dir):
+            return None
+
+        for name in os.listdir(target_dir):
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(target_dir, name)
+            frontmatter = _read_frontmatter(path)
+            if frontmatter.get("typ") != self.report_type:
+                continue
+            if frontmatter.get("signal_tidpunkt") == signal_dt:
+                return path
+        return None
+
+    async def _try_append_reply_attachments(
+        self,
+        *,
+        attachments: list[dict[str, Any]],
+        quote: dict[str, Any] | None,
+        group_title: str,
+        effective_vault_subdir: str | None,
+        signal_dt: datetime.datetime,
+        source_name: str | None,
+        source_number: str | None,
+        message_text: str | None,
+    ) -> bool:
+        if not quote or not attachments:
+            return False
+
+        quote_id = quote.get("id")
+        if not isinstance(quote_id, int | float) or quote_id <= 0:
+            return False
+
+        target_file = self._find_quoted_report_file(
+            group_title=group_title,
+            quote_timestamp_ms=int(quote_id),
+            effective_vault_subdir=effective_vault_subdir,
+        )
+        if not target_file:
+            return False
+
+        attachment_links = await save_attachments(
+            attachments,
+            os.path.dirname(target_file),
+            signal_dt,
+            source_name,
+            source_number,
+        )
+        if not attachment_links:
+            return False
+
+        sender_display = format_sender_display(source_name, source_number)
+        caption = apply_regex_links(message_text.strip()) if message_text and message_text.strip() else None
+
+        lines = [
+            "## Svarsbilagor",
+            "",
+            f"**Tid:** {signal_dt.strftime('%Y-%m-%dT%H:%M:%S')}",
+            "",
+            f"**Avsändare:** {sender_display}",
+            "",
+        ]
+        if caption:
+            lines.extend([f"**Meddelande:** {caption}", ""])
+        lines.extend(attachment_links)
+
+        with open(target_file, "a", encoding="utf-8") as handle:
+            handle.write("\n\n" + "\n".join(lines) + "\n")
+
+        return True
+
     async def run(
         self,
         *,
@@ -270,11 +390,7 @@ class StructuredReportPipeline:
         if "syncMessage" in envelope and "dataMessage" not in envelope:
             return False
 
-        message_text, group_title, group_id, timestamp_ms = extract_message_details(envelope)
-        if not self.matches_message(message_text):
-            return False
-
-        fields = self.parse_report(message_text or "")
+        message_text, group_title, group_id, timestamp_ms, attachments, quote = extract_message_details(envelope)
 
         source_name = envelope.get("sourceName")
         source_number = envelope.get("sourceNumber") or envelope.get("source")
@@ -289,6 +405,27 @@ class StructuredReportPipeline:
         signal_dt = (
             datetime.datetime.fromtimestamp(signal_timestamp_ms / 1000, tz=cfg.TIMEZONE) if signal_timestamp_ms else dt
         )
+
+        resolved_group_title = group_title or "inbox"
+        effective_vault_subdir = self._resolve_effective_subdir()
+
+        if await self._try_append_reply_attachments(
+            attachments=attachments,
+            quote=quote,
+            group_title=resolved_group_title,
+            effective_vault_subdir=effective_vault_subdir,
+            signal_dt=signal_dt,
+            source_name=source_name,
+            source_number=source_number,
+            message_text=message_text,
+        ):
+            return True
+
+        if not self.matches_message(message_text):
+            return False
+
+        fields = self.parse_report(message_text or "")
+
         source_id = envelope.get("sourceUuid")
         if not source_number:
             raise ValueError(f"{self.report_id_prefix} Signal sender number is missing")
@@ -297,16 +434,6 @@ class StructuredReportPipeline:
 
         raw_tnr = fields[self.tnr_field_name].strip()
         report_dt = self.build_report_datetime(fields=fields, reference_dt=dt)
-
-        resolved_group_title = group_title or "inbox"
-
-        # vault_subdir: per-pipeline settings win over class-level default
-        pipeline_settings = cfg.PIPELINE_SETTINGS.get(self.name, {}) if isinstance(cfg.PIPELINE_SETTINGS, dict) else {}
-        configured_subdir = pipeline_settings.get("vault_subdir", self.vault_subdir)
-        enabled_override = pipeline_settings.get("vault_subdir_enabled")
-        use_subdir = enabled_override if isinstance(enabled_override, bool) else bool(configured_subdir)
-
-        effective_vault_subdir = configured_subdir if use_subdir else None
 
         filepath, resolved_tnr = build_report_filepath(
             resolved_group_title,
@@ -330,6 +457,17 @@ class StructuredReportPipeline:
                 envelope=envelope,
             )
         )
+
+        if attachments:
+            attachment_links = await save_attachments(
+                attachments,
+                os.path.dirname(filepath),
+                signal_dt,
+                source_name,
+                source_number,
+            )
+            if attachment_links:
+                content = _append_section(content, ["## Bilagor", "", *attachment_links])
 
         with open(filepath, "w", encoding="utf-8") as handle:
             handle.write(content)

--- a/oden/templates/web/css/base.css
+++ b/oden/templates/web/css/base.css
@@ -28,7 +28,7 @@
     padding: 0;
 }
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Segoe UI Symbol', sans-serif;
     background: var(--color-bg-primary);
     color: var(--color-text);
     min-height: 100vh;

--- a/oden/templates/web/js/dashboard/shared.js
+++ b/oden/templates/web/js/dashboard/shared.js
@@ -19,7 +19,7 @@ function showConfigMessage(message, type) {
         msgDiv.classList.add('success');
         msgDiv.querySelector('.icon').textContent = '✓';
     } else {
-        msgDiv.querySelector('.icon').textContent = '⚠️';
+        msgDiv.querySelector('.icon').textContent = '⚠';
     }
     msgDiv.classList.add('show');
     setTimeout(() => msgDiv.classList.remove('show'), 5000);

--- a/oden/templates/web/setup.html
+++ b/oden/templates/web/setup.html
@@ -94,7 +94,7 @@
                         <input type="radio" name="setup-method" value="register" style="width: 18px; height: 18px;">
                         <div>
                             <strong style="color: #ffb74d;">Registrera nytt nummer</strong>
-                            <p style="color: #888; font-size: 0.85em; margin: 4px 0 0 0;">⚠️ Använd INTE ditt huvudnummer!</p>
+                            <p style="color: #888; font-size: 0.85em; margin: 4px 0 0 0;">⚠ Använd INTE ditt huvudnummer!</p>
                         </div>
                     </label>
                 </div>

--- a/oden/web_server.py
+++ b/oden/web_server.py
@@ -8,6 +8,7 @@ and initial setup wizard for first-run configuration.
 import asyncio
 import base64
 import logging
+from pathlib import Path
 
 import aiohttp_jinja2
 import jinja2
@@ -98,6 +99,22 @@ from oden.web_handlers.template_handlers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_logo_path(bundle_path: Path) -> Path | None:
+    """Resolve the preferred web GUI logo path.
+
+    Prefer the current logo asset first, then legacy fallbacks.
+    """
+    candidates = [
+        bundle_path / "images" / "logo.png",
+        bundle_path / "images" / "oden_1024.png",
+        bundle_path / "images" / "logo_small.jpg",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
 
 
 async def index_handler(request: web.Request) -> web.Response:
@@ -212,9 +229,10 @@ def create_app(setup_mode: bool = False) -> web.Application:
         loader=jinja2.PackageLoader("oden", "templates/web"),
         autoescape=jinja2.select_autoescape(["html"]),
     )
-    logo_path = get_bundle_path() / "images" / "oden_1024.png"
-    if logo_path.exists():
-        env.globals["oden_logo_uri"] = "data:image/png;base64," + base64.b64encode(logo_path.read_bytes()).decode()
+    logo_path = _resolve_logo_path(get_bundle_path())
+    if logo_path is not None:
+        mime_type = "image/jpeg" if logo_path.suffix.lower() in {".jpg", ".jpeg"} else "image/png"
+        env.globals["oden_logo_uri"] = f"data:{mime_type};base64," + base64.b64encode(logo_path.read_bytes()).decode()
 
     # Setup routes (always available)
     app.router.add_get("/setup", setup_handler)

--- a/tests/test_fors_pipeline.py
+++ b/tests/test_fors_pipeline.py
@@ -15,6 +15,7 @@ def _make_msg_data(
     *,
     group="7s-test",
     tnr="241330",
+    attachments=None,
 ):
     return {
         "envelope": {
@@ -36,6 +37,7 @@ def _make_msg_data(
                     "SLUT!\n"
                 ),
                 "groupV2": {"name": group, "id": "group123"},
+                "attachments": attachments or [],
             },
         }
     }
@@ -184,3 +186,32 @@ class TestForsPipelineRun(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertFalse(handled)
+
+    @patch("oden.pipelines.structured_report.save_attachments", new_callable=AsyncMock)
+    @patch("oden.pipelines.structured_report.get_app_state")
+    async def test_run_includes_attachment_links_for_fors_message(self, mock_get_app_state, mock_save_attachments):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+        mock_save_attachments.return_value = ["![[attachments/fors-bild.jpg]]"]
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("oden.config.VAULT_PATH", tmpdir),
+            patch("oden.config.GROUP_SPLIT_ENABLED", False),
+        ):
+            pipeline = ForsPipeline()
+
+            handled = await pipeline.run(
+                msg_data=_make_msg_data(attachments=[{"id": "att-1", "filename": "fors-bild.jpg"}]),
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "TNR241330.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("## Bilagor", content)
+        self.assertIn("![[attachments/fors-bild.jpg]]", content)

--- a/tests/test_pedars_pipeline.py
+++ b/tests/test_pedars_pipeline.py
@@ -11,7 +11,7 @@ _TIMESTAMP = int(datetime.datetime(2026, 6, 24, 15, 45, 5, tzinfo=cfg.TIMEZONE).
 _SERVER_RECEIVED_TIMESTAMP = int(datetime.datetime(2026, 6, 24, 15, 45, 9, tzinfo=cfg.TIMEZONE).timestamp() * 1000)
 
 
-def _make_msg_data(*, group="7s-test", tnr="241345"):
+def _make_msg_data(*, group="7s-test", tnr="241345", attachments=None):
     return {
         "envelope": {
             "sourceName": "Nicklas",
@@ -47,6 +47,7 @@ def _make_msg_data(*, group="7s-test", tnr="241345"):
                     "SLUT!\n"
                 ),
                 "groupV2": {"name": group, "id": "group123"},
+                "attachments": attachments or [],
             },
         }
     }
@@ -170,3 +171,32 @@ class TestPedarsPipelineRun(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertFalse(handled)
+
+    @patch("oden.pipelines.structured_report.save_attachments", new_callable=AsyncMock)
+    @patch("oden.pipelines.structured_report.get_app_state")
+    async def test_run_includes_attachment_links_for_pedars_message(self, mock_get_app_state, mock_save_attachments):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+        mock_save_attachments.return_value = ["![[attachments/pedars-bild.jpg]]"]
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("oden.config.VAULT_PATH", tmpdir),
+            patch("oden.config.GROUP_SPLIT_ENABLED", False),
+        ):
+            pipeline = PedarsPipeline()
+
+            handled = await pipeline.run(
+                msg_data=_make_msg_data(attachments=[{"id": "att-1", "filename": "pedars-bild.jpg"}]),
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "TNR241345.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("## Bilagor", content)
+        self.assertIn("![[attachments/pedars-bild.jpg]]", content)

--- a/tests/test_seven_s_pipeline.py
+++ b/tests/test_seven_s_pipeline.py
@@ -26,8 +26,17 @@ def _make_msg_data(
     stund="221520",
     source_id="dd1bac1d-b955-4ac0-9d53-14053c4fe69f",
     sedan="Återgår till bas",
+    attachments=None,
+    quote=None,
+    message_override=None,
 ):
     sedan_line = f"Sedan: {sedan}\n" if sedan is not None else ""
+    message = message_override or (
+        f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: {tnr}\nStund: {stund}\n"
+        f"Ställe: {stalle}\nStyrka: 1\nSlag: Vi\nSysselsättning: Patrull\n"
+        f"Symbol: {symbol}\nSagesman: {sagesman}\n"
+        f"{sedan_line}"
+    )
     return {
         "envelope": {
             "sourceName": "Nicklas",
@@ -36,13 +45,10 @@ def _make_msg_data(
             "timestamp": _TIMESTAMP,
             "serverReceivedTimestamp": _SERVER_RECEIVED_TIMESTAMP,
             "dataMessage": {
-                "message": (
-                    f"7S RAPPORT\nTill: TST\nFrån: TS\nTNR: {tnr}\nStund: {stund}\n"
-                    f"Ställe: {stalle}\nStyrka: 1\nSlag: Vi\nSysselsättning: Patrull\n"
-                    f"Symbol: {symbol}\nSagesman: {sagesman}\n"
-                    f"{sedan_line}"
-                ),
+                "message": message,
                 "groupV2": {"name": group, "id": "group123"},
+                "attachments": attachments or [],
+                "quote": quote,
             },
         }
     }
@@ -446,6 +452,71 @@ class TestSevenSPipelineRun(unittest.IsolatedAsyncioTestCase):
         self.assertIn("non-canonical", "\n".join(captured_logs.output))
         self.assertIn("sagesman: 2A GRUPP", content)
         self.assertIn("**Sagesman:** 2A GRUPP", content)
+
+    @patch("oden.pipelines.structured_report.save_attachments", new_callable=AsyncMock)
+    @patch("oden.pipelines.structured_report.get_app_state")
+    async def test_run_includes_attachment_links_for_7s_message(self, mock_get_app_state, mock_save_attachments):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+        mock_save_attachments.return_value = ["![[attachments/bild-1.jpg]]"]
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("oden.config.VAULT_PATH", tmpdir),
+            patch("oden.config.GROUP_SPLIT_ENABLED", False),
+        ):
+            pipeline = SevenSPipeline()
+            handled = await pipeline.run(
+                msg_data=_make_msg_data(attachments=[{"id": "att-1", "filename": "bild-1.jpg"}]),
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            output_path = Path(tmpdir) / "TNR221520.md"
+            self.assertTrue(output_path.exists())
+            content = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("## Bilagor", content)
+        self.assertIn("![[attachments/bild-1.jpg]]", content)
+
+    @patch("oden.pipelines.structured_report.save_attachments", new_callable=AsyncMock)
+    @patch("oden.pipelines.structured_report.get_app_state")
+    async def test_run_appends_reply_attachments_to_quoted_report(self, mock_get_app_state, mock_save_attachments):
+        app_state = Mock()
+        app_state.resolve_contact_name.return_value = "Nicklas"
+        mock_get_app_state.return_value = app_state
+        mock_save_attachments.return_value = ["![[attachments/svar-bild.jpg]]"]
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("oden.config.VAULT_PATH", tmpdir),
+            patch("oden.config.GROUP_SPLIT_ENABLED", False),
+        ):
+            target_path = Path(tmpdir) / "TNR221520.md"
+            target_path.write_text(
+                '---\ntyp: 7S-rapport\nsignal_tidpunkt: "2026-06-22T19:31:05"\n---\n\nBefintlig rapport\n',
+                encoding="utf-8",
+            )
+
+            pipeline = SevenSPipeline()
+            handled = await pipeline.run(
+                msg_data=_make_msg_data(
+                    attachments=[{"id": "att-2", "filename": "svar-bild.jpg"}],
+                    quote={"id": _TIMESTAMP},
+                    message_override="Bildbevis från platsen",
+                ),
+                reader=AsyncMock(),
+                writer=AsyncMock(),
+            )
+
+            self.assertTrue(handled)
+            content = target_path.read_text(encoding="utf-8")
+
+        self.assertIn("## Svarsbilagor", content)
+        self.assertIn("**Meddelande:** Bildbevis från platsen", content)
+        self.assertIn("![[attachments/svar-bild.jpg]]", content)
 
     @patch("oden.pipelines.structured_report.get_app_state")
     async def test_run_omits_optional_sedan_when_missing(self, mock_get_app_state):


### PR DESCRIPTION
## Summary
- add attachment support to structured report pipelines (7S, FORS, PEDARS) when image+text are sent in the same message
- add quote-reply attachment handling that appends images to the quoted structured report as a `Svarsbilagor` section
- add tests for same-message attachments and quoted-reply attachments

## Validation
- ruff check .
- ruff format .
- pytest (310 passed)
