### PR TITLE
feat(web-gui): show group members as expandable tree

### DIFF
--- a/oden/config_db.py
+++ b/oden/config_db.py
@@ -253,8 +253,22 @@ def init_db(db_path: Path) -> None:
             """)
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_pipeline_events_run_id ON pipeline_events(run_id)")
 
+        # Migration to schema version 6: add contacts table (restart recovery,
+        # same purpose as the groups table — signal-cli's listContacts result
+        # is only held in memory otherwise).
+        if current_version < 6:
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS contacts (
+                    number TEXT NOT NULL,
+                    account TEXT NOT NULL DEFAULT '',
+                    data TEXT NOT NULL,
+                    last_seen TEXT NOT NULL DEFAULT '',
+                    PRIMARY KEY (number, account)
+                )
+            """)
+
         # Store current schema version (never downgrade)
-        latest_version = max(current_version, 5)
+        latest_version = max(current_version, 6)
         cursor.execute(
             "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
             ("schema_version", str(latest_version)),

--- a/oden/contacts_db.py
+++ b/oden/contacts_db.py
@@ -1,0 +1,68 @@
+"""
+Contacts table CRUD for Oden's SQLite config database.
+
+Manages Signal contact persistence for restart recovery, mirroring groups_db.py.
+Each contact is stored as its raw signal-cli dict (JSON) so no fields are lost.
+"""
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from oden.config_db import init_db
+
+logger = logging.getLogger(__name__)
+
+
+def upsert_contacts_bulk(db_path: Path, contacts: list[dict], account: str = "") -> int:
+    """Bulk upsert a list of contact dicts (as returned by listContacts).
+
+    Returns the number of contacts written.
+    """
+    if not contacts:
+        return 0
+    if not db_path.exists():
+        init_db(db_path)
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        rows = [(c["number"], account, json.dumps(c), now) for c in contacts if c.get("number")]
+        cursor.executemany(
+            "INSERT OR REPLACE INTO contacts (number, account, data, last_seen) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+        return len(rows)
+    except sqlite3.Error as e:
+        logger.error("Error bulk-upserting contacts: %s", e)
+        return 0
+    finally:
+        conn.close()
+
+
+def get_all_contacts(db_path: Path, account: str | None = None) -> list[dict]:
+    """Return contacts stored in the database, as their raw signal-cli dicts.
+
+    If *account* is given, only contacts belonging to that account are returned.
+    """
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if account is not None:
+            cursor.execute("SELECT data FROM contacts WHERE account = ?", (account,))
+        else:
+            cursor.execute("SELECT data FROM contacts")
+        return [json.loads(row[0]) for row in cursor.fetchall()]
+    except sqlite3.Error as e:
+        logger.error("Error reading contacts: %s", e)
+        return []
+    finally:
+        conn.close()

--- a/oden/signal_listener.py
+++ b/oden/signal_listener.py
@@ -25,6 +25,7 @@ from oden.retention_db import cleanup_old_data
 logger = logging.getLogger(__name__)
 
 RETENTION_CLEANUP_INTERVAL_SECONDS = 3600
+GROUPS_CONTACTS_REFRESH_INTERVAL_SECONDS = 900
 
 
 async def send_startup_message(writer: asyncio.StreamWriter, groups: list[dict] | None = None) -> None:
@@ -183,8 +184,11 @@ async def log_contacts() -> None:
     """Fetches contacts from signal-cli and caches them in app_state.
 
     Used for name resolution (fallback when envelope sourceName is empty).
+    Persists to the database so contacts survive restarts, and falls back
+    to the database if the RPC call fails (same pattern as log_groups).
     """
     from oden import config as cfg
+    from oden.contacts_db import get_all_contacts, upsert_contacts_bulk
 
     app_state = get_app_state()
 
@@ -197,10 +201,18 @@ async def log_contacts() -> None:
         if response and "result" in response:
             contacts = response["result"]
             app_state.update_contacts(contacts)
-        else:
-            logger.debug("listContacts returned no result")
+            count = upsert_contacts_bulk(cfg.CONFIG_DB, contacts, account=cfg.SIGNAL_NUMBER)
+            if count:
+                logger.debug("Persisted %d contacts to database", count)
+            return
+        logger.debug("listContacts returned no result, loading from database")
     except Exception as e:
-        logger.warning("Could not fetch contacts via RPC: %s", e)
+        logger.warning("Could not fetch contacts via RPC: %s — loading from database", e)
+
+    db_contacts = get_all_contacts(cfg.CONFIG_DB, account=cfg.SIGNAL_NUMBER)
+    if db_contacts:
+        logger.info("Loaded %d contact(s) from database (offline cache)", len(db_contacts))
+        app_state.update_contacts(db_contacts)
 
 
 async def update_profile(writer: asyncio.StreamWriter, display_name: str | None) -> None:
@@ -254,6 +266,18 @@ async def _reader_loop(reader: asyncio.StreamReader, app_state: object) -> None:
         app_state.dispatch_line(data)
 
 
+async def _periodic_groups_contacts_refresh(writer: asyncio.StreamWriter) -> None:
+    """Periodically re-fetch groups and contacts so the web GUI stays current
+    without requiring a manual "Uppdatera" click."""
+    while True:
+        await asyncio.sleep(GROUPS_CONTACTS_REFRESH_INTERVAL_SECONDS)
+        try:
+            await log_groups(writer)
+            await log_contacts()
+        except Exception as e:
+            logger.warning("Periodic groups/contacts refresh failed: %s", e)
+
+
 async def subscribe_and_listen(host: str, port: int) -> None:
     """Connects to signal-cli via TCP socket, subscribes to messages, and processes them.
 
@@ -284,6 +308,7 @@ async def subscribe_and_listen(host: str, port: int) -> None:
         # Start the reader/dispatcher loop as a background task so that
         # RPC responses are consumed while we issue startup calls.
         reader_task = asyncio.create_task(_reader_loop(reader, app_state))
+        refresh_task = asyncio.create_task(_periodic_groups_contacts_refresh(writer))
 
         await update_profile(writer, DISPLAY_NAME)
         groups = await log_groups(writer)
@@ -381,6 +406,9 @@ async def subscribe_and_listen(host: str, port: int) -> None:
             reader_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await reader_task
+            refresh_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await refresh_task
 
     except ConnectionRefusedError as e:
         logger.error(f"Connection to signal-cli daemon failed: {e}")

--- a/oden/templates/web/css/dashboard.css
+++ b/oden/templates/web/css/dashboard.css
@@ -224,6 +224,17 @@ td {
     font-size: 0.85em;
     margin-left: 4px;
 }
+.blocked-badge {
+    color: #ff5252;
+    font-size: 0.85em;
+    margin-left: 4px;
+}
+.member-note {
+    color: var(--color-text-muted);
+    font-size: 0.9em;
+    font-style: italic;
+    margin-left: 20px;
+}
 .group-item.ignored {
     opacity: 0.6;
     background: #1a1520;

--- a/oden/templates/web/css/dashboard.css
+++ b/oden/templates/web/css/dashboard.css
@@ -185,20 +185,48 @@ td {
     gap: 8px;
 }
 .group-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     padding: 10px 15px;
     background: var(--color-bg-inset);
     border-radius: 4px;
     border: 1px solid var(--color-border);
 }
+.group-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.group-members {
+    margin-top: 6px;
+}
+.group-members summary {
+    cursor: pointer;
+    font-size: 0.85em;
+    color: var(--color-text-muted);
+}
+.group-member-list {
+    list-style: none;
+    margin: 6px 0 0 16px;
+    padding: 0;
+    font-size: 0.85em;
+}
+.group-member-list li {
+    padding: 3px 0;
+    border-bottom: 1px solid var(--color-border);
+}
+.group-member-list li:last-child {
+    border-bottom: none;
+}
+.mono {
+    font-family: monospace;
+}
+.admin-badge {
+    color: #4caf50;
+    font-size: 0.85em;
+    margin-left: 4px;
+}
 .group-item.ignored {
     opacity: 0.6;
     background: #1a1520;
-}
-.group-info {
-    flex: 1;
 }
 .group-name {
     font-weight: 500;

--- a/oden/templates/web/includes/dashboard/groups.html
+++ b/oden/templates/web/includes/dashboard/groups.html
@@ -11,6 +11,28 @@
 </div>
 
 <div class="card full-width">
+    <h2>➕ Skapa grupp</h2>
+    <form id="create-group-form">
+        <div class="form-group">
+            <label for="create-group-name">Gruppnamn</label>
+            <input type="text" id="create-group-name" required>
+        </div>
+        <div class="form-group">
+            <label>Bjud in kontakter</label>
+            <div id="create-group-contacts" class="group-member-list" style="max-height: 200px; overflow-y: auto;">
+                <div class="empty-state">Laddar kontakter...</div>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="create-group-add-number">Lägg till nummer manuellt</label>
+            <input type="text" id="create-group-add-number" placeholder="+46...">
+        </div>
+        <button type="submit" class="btn btn-primary" id="create-group-btn">Skapa grupp</button>
+    </form>
+    <div id="create-group-message" class="message"></div>
+</div>
+
+<div class="card full-width">
     <h2>🔗 Gå med i grupp</h2>
     <form id="join-group-form">
         <div class="form-group">

--- a/oden/templates/web/js/dashboard/groups.js
+++ b/oden/templates/web/js/dashboard/groups.js
@@ -46,7 +46,7 @@ function _renderGroupMemberTree(group) {
     }
     const rows = members.map(m => {
         const name = escapeHtml(m.name && m.name !== 'Okänd' ? m.name : '');
-        const number = escapeHtml(m.number || '');
+        const number = escapeHtml(m.number || 'Okänd medlem');
         const adminBadge = m.role === 'ADMINISTRATOR' ? '<span class="admin-badge">Admin</span>' : '';
         const blockedBadge = m.isBlocked ? '<span class="blocked-badge">Blockerad</span>' : '';
         const note = m.note ? `<div class="member-note">${escapeHtml(m.note)}</div>` : '';
@@ -104,7 +104,7 @@ function _renderGroupMembers(members) {
     }
     container.innerHTML = members.map(m => {
         const name = escapeHtml(m.name && m.name !== 'Okänd' ? m.name : '');
-        const number = escapeHtml(m.number || '');
+        const number = escapeHtml(m.number || 'Okänd medlem');
         const isAdmin = m.role === 'ADMINISTRATOR';
         const badge = isAdmin ? '<span style="color: #4caf50; font-size: 0.85em; margin-left: 4px;">Admin</span>' : '';
         const adminBtn = isAdmin

--- a/oden/templates/web/js/dashboard/groups.js
+++ b/oden/templates/web/js/dashboard/groups.js
@@ -311,3 +311,79 @@ async function handleJoinGroupSubmit(e) {
         submitBtn.textContent = 'Gå med i grupp';
     }
 }
+
+// ========== Create group ==========
+
+async function loadCreateGroupContacts() {
+    const container = document.getElementById('create-group-contacts');
+    try {
+        const response = await fetch('/api/contacts');
+        const data = await response.json();
+        const contacts = data.contacts || [];
+
+        if (contacts.length === 0) {
+            container.innerHTML = '<div class="empty-state">Inga kontakter hittades</div>';
+            return;
+        }
+
+        container.innerHTML = contacts.map(c => {
+            const number = escapeHtml(c.number || '');
+            const name = escapeHtml(c.name || c.nickName || number);
+            return `<label style="display: block; padding: 3px 0;"><input type="checkbox" value="${number}"> ${name}</label>`;
+        }).join('');
+    } catch (error) {
+        container.innerHTML = '<div class="empty-state">Kunde inte ladda kontakter</div>';
+    }
+}
+
+async function handleCreateGroupSubmit(e) {
+    e.preventDefault();
+    const nameInput = document.getElementById('create-group-name');
+    const submitBtn = document.getElementById('create-group-btn');
+    const messageDiv = document.getElementById('create-group-message');
+    const name = nameInput.value.trim();
+
+    if (!name) return;
+
+    const checked = Array.from(
+        document.querySelectorAll('#create-group-contacts input[type="checkbox"]:checked')
+    ).map(cb => cb.value);
+
+    const manualInput = document.getElementById('create-group-add-number');
+    const manualNumbers = manualInput.value.split(',').map(s => s.trim()).filter(Boolean);
+
+    const member = [...new Set([...checked, ...manualNumbers])];
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Skapar...';
+    messageDiv.className = 'message';
+    messageDiv.textContent = '';
+
+    try {
+        const response = await fetch('/api/groups/create', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, member }),
+        });
+        const result = await response.json();
+
+        if (response.ok && result.success) {
+            messageDiv.className = 'message success';
+            messageDiv.textContent = 'Grupp skapad!';
+            nameInput.value = '';
+            manualInput.value = '';
+            document.querySelectorAll('#create-group-contacts input[type="checkbox"]:checked')
+                .forEach(cb => { cb.checked = false; });
+            await fetchGroups();
+        } else {
+            messageDiv.className = 'message error';
+            messageDiv.textContent = result.error || 'Kunde inte skapa grupp';
+        }
+    } catch (error) {
+        messageDiv.className = 'message error';
+        messageDiv.textContent = 'Nätverksfel: ' + error.message;
+    } finally {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Skapa grupp';
+    }
+}

--- a/oden/templates/web/js/dashboard/groups.js
+++ b/oden/templates/web/js/dashboard/groups.js
@@ -47,8 +47,10 @@ function _renderGroupMemberTree(group) {
     const rows = members.map(m => {
         const name = escapeHtml(m.name && m.name !== 'Okänd' ? m.name : '');
         const number = escapeHtml(m.number || '');
-        const badge = m.role === 'ADMINISTRATOR' ? '<span class="admin-badge">Admin</span>' : '';
-        return `<li><span class="mono">${number}</span>${name ? ' — ' + name : ''}${badge}</li>`;
+        const adminBadge = m.role === 'ADMINISTRATOR' ? '<span class="admin-badge">Admin</span>' : '';
+        const blockedBadge = m.isBlocked ? '<span class="blocked-badge">Blockerad</span>' : '';
+        const note = m.note ? `<div class="member-note">${escapeHtml(m.note)}</div>` : '';
+        return `<li><span class="mono">${number}</span>${name ? ' — ' + name : ''}${adminBadge}${blockedBadge}${note}</li>`;
     }).join('');
     return `
         <details class="group-members">

--- a/oden/templates/web/js/dashboard/groups.js
+++ b/oden/templates/web/js/dashboard/groups.js
@@ -23,19 +23,39 @@ async function fetchGroups() {
                 : '';
             return `
                 <div class="group-item" data-group-name="${escapeHtml(group.name)}">
-                    <div class="group-info">
+                    <div class="group-header">
                         <div class="group-name">${escapeHtml(group.name)}</div>
-                        <div class="group-meta">${group.memberCount} medlemmar</div>
+                        <div class="group-buttons">${editBtn}</div>
                     </div>
-                    <div class="group-buttons">
-                        ${editBtn}
-                    </div>
+                    ${_renderGroupMemberTree(group)}
                 </div>
             `;
         }).join('');
     } catch (error) {
         console.error('Error fetching groups:', error);
     }
+}
+
+function _renderGroupMemberTree(group) {
+    if (!group.memberCount) {
+        return '<div class="group-meta">0 medlemmar</div>';
+    }
+    const members = group.members || [];
+    if (!members.length) {
+        return `<div class="group-meta">${group.memberCount} medlemmar (uppdatera för att se namn)</div>`;
+    }
+    const rows = members.map(m => {
+        const name = escapeHtml(m.name && m.name !== 'Okänd' ? m.name : '');
+        const number = escapeHtml(m.number || '');
+        const badge = m.role === 'ADMINISTRATOR' ? '<span class="admin-badge">Admin</span>' : '';
+        return `<li><span class="mono">${number}</span>${name ? ' — ' + name : ''}${badge}</li>`;
+    }).join('');
+    return `
+        <details class="group-members">
+            <summary>${group.memberCount} medlemmar</summary>
+            <ul class="group-member-list">${rows}</ul>
+        </details>
+    `;
 }
 
 // ========== Group edit modal ==========

--- a/oden/templates/web/js/dashboard/init.js
+++ b/oden/templates/web/js/dashboard/init.js
@@ -7,6 +7,7 @@
 fetchLogs();
 fetchInvitations();
 fetchGroups();
+loadCreateGroupContacts();
 loadConfigForm();
 loadSignalConfig();
 loadSignalCliStatus();
@@ -21,6 +22,7 @@ setInterval(loadSignalCliStatus, 30000); // signal-cli status: every 30 seconds
 
 // ========== Form Handlers ==========
 document.getElementById('join-group-form').addEventListener('submit', handleJoinGroupSubmit);
+document.getElementById('create-group-form').addEventListener('submit', handleCreateGroupSubmit);
 
 // Prevent form submission on Enter (auto-save handles saving)
 ['config-form', 'config-form-advanced'].forEach(formId => {

--- a/oden/web_handlers/contact_handlers.py
+++ b/oden/web_handlers/contact_handlers.py
@@ -10,6 +10,7 @@ from aiohttp import web
 
 from oden import config as cfg
 from oden.app_state import get_app_state
+from oden.contacts_db import upsert_contacts_bulk
 from oden.web_handlers._helpers import handle_errors, parse_json_body, require_writer
 
 logger = logging.getLogger(__name__)
@@ -36,6 +37,7 @@ async def contacts_refresh_handler(request: web.Request) -> web.Response:
     if response and "result" in response:
         contacts = response["result"]
         app_state.update_contacts(contacts)
+        upsert_contacts_bulk(cfg.CONFIG_DB, contacts, account=cfg.SIGNAL_NUMBER)
         return web.json_response(
             {
                 "success": True,
@@ -95,6 +97,7 @@ async def update_contact_handler(request: web.Request) -> web.Response:
     )
     if contacts_resp and "result" in contacts_resp:
         app_state.update_contacts(contacts_resp["result"])
+        upsert_contacts_bulk(cfg.CONFIG_DB, contacts_resp["result"], account=cfg.SIGNAL_NUMBER)
 
     logger.info("Contact %s updated", number)
     return web.json_response({"success": True})

--- a/oden/web_handlers/group_handlers.py
+++ b/oden/web_handlers/group_handlers.py
@@ -310,6 +310,51 @@ async def update_group_handler(request: web.Request) -> web.Response:
     return web.json_response({"success": True})
 
 
+@handle_errors("create group")
+@parse_json_body
+async def create_group_handler(request: web.Request) -> web.Response:
+    """Create a new group via signal-cli createGroup RPC."""
+    data = request["json_body"]
+    name = data.get("name", "").strip()
+
+    if not name:
+        return web.json_response({"success": False, "error": "Inget gruppnamn angivet"}, status=400)
+
+    # Check writer after validation so a missing name returns 400, not 503
+    app_state = get_app_state()
+    if not app_state.writer:
+        return web.json_response(
+            {"success": False, "error": "Inte ansluten till signal-cli"},
+            status=503,
+        )
+
+    params: dict = {"account": cfg.SIGNAL_NUMBER, "name": name}
+    members = data.get("member") or []
+    if members:
+        params["member"] = members
+
+    result = await app_state.send_jsonrpc("createGroup", params=params)
+
+    if result is None:
+        return web.json_response(
+            {"success": False, "error": "Inget svar från signal-cli"},
+            status=502,
+        )
+
+    # Refresh groups cache after creation
+    refresh = await app_state.send_jsonrpc(
+        "listGroups",
+        params={"account": cfg.SIGNAL_NUMBER},
+        timeout=10.0,
+    )
+    if refresh and "result" in refresh:
+        app_state.update_groups(refresh["result"])
+        upsert_groups_bulk(cfg.CONFIG_DB, refresh["result"], account=cfg.SIGNAL_NUMBER)
+
+    logger.info("Group '%s' created", name)
+    return web.json_response({"success": True})
+
+
 @handle_errors("refresh groups")
 @require_writer
 async def refresh_groups_handler(request: web.Request) -> web.Response:

--- a/oden/web_handlers/group_handlers.py
+++ b/oden/web_handlers/group_handlers.py
@@ -62,6 +62,14 @@ async def groups_handler(request: web.Request) -> web.Response:
                     else:
                         continue
                     display = app_state.resolve_contact_name(num, None)
+                    if display == "Okänd":
+                        # No saved contact name — fall back to the Signal profile
+                        # name (givenName/familyName), same as the Contacts tab.
+                        profile = (app_state.contacts.get(num) or {}).get("profile") or {}
+                        profile_name = " ".join(
+                            p for p in (profile.get("givenName"), profile.get("familyName")) if p
+                        )
+                        display = profile_name or display
                     members.append({"number": num, "name": display, "role": role})
                     if num == cfg.SIGNAL_NUMBER and role == "ADMINISTRATOR":
                         is_admin = True

--- a/oden/web_handlers/group_handlers.py
+++ b/oden/web_handlers/group_handlers.py
@@ -61,14 +61,23 @@ async def groups_handler(request: web.Request) -> web.Response:
                         role = "DEFAULT"
                     else:
                         continue
+                    contact = app_state.contacts.get(num) or {}
                     display = app_state.resolve_contact_name(num, None)
                     if display == "Okänd":
                         # No saved contact name — fall back to the Signal profile
                         # name (givenName/familyName), same as the Contacts tab.
-                        profile = (app_state.contacts.get(num) or {}).get("profile") or {}
+                        profile = contact.get("profile") or {}
                         profile_name = " ".join(p for p in (profile.get("givenName"), profile.get("familyName")) if p)
                         display = profile_name or display
-                    members.append({"number": num, "name": display, "role": role})
+                    members.append(
+                        {
+                            "number": num,
+                            "name": display,
+                            "role": role,
+                            "note": contact.get("note", ""),
+                            "isBlocked": bool(contact.get("isBlocked", False)),
+                        }
+                    )
                     if num == cfg.SIGNAL_NUMBER and role == "ADMINISTRATOR":
                         is_admin = True
                 merged[gid] = {

--- a/oden/web_handlers/group_handlers.py
+++ b/oden/web_handlers/group_handlers.py
@@ -292,11 +292,11 @@ async def update_group_handler(request: web.Request) -> web.Response:
 
     result = await app_state.send_jsonrpc("updateGroup", params=params)
 
-    if result is None:
-        return web.json_response(
-            {"success": False, "error": "Inget svar från signal-cli"},
-            status=502,
-        )
+    if not result or "result" not in result:
+        error_msg = "Inget svar från signal-cli"
+        if result and "error" in result:
+            error_msg = result["error"].get("message", error_msg)
+        return web.json_response({"success": False, "error": error_msg}, status=502)
 
     # Refresh groups cache after update
     refresh = await app_state.send_jsonrpc(
@@ -337,11 +337,11 @@ async def create_group_handler(request: web.Request) -> web.Response:
 
     result = await app_state.send_jsonrpc("createGroup", params=params)
 
-    if result is None:
-        return web.json_response(
-            {"success": False, "error": "Inget svar från signal-cli"},
-            status=502,
-        )
+    if not result or "result" not in result:
+        error_msg = "Inget svar från signal-cli"
+        if result and "error" in result:
+            error_msg = result["error"].get("message", error_msg)
+        return web.json_response({"success": False, "error": error_msg}, status=502)
 
     # Refresh groups cache after creation
     refresh = await app_state.send_jsonrpc(

--- a/oden/web_handlers/group_handlers.py
+++ b/oden/web_handlers/group_handlers.py
@@ -66,9 +66,7 @@ async def groups_handler(request: web.Request) -> web.Response:
                         # No saved contact name — fall back to the Signal profile
                         # name (givenName/familyName), same as the Contacts tab.
                         profile = (app_state.contacts.get(num) or {}).get("profile") or {}
-                        profile_name = " ".join(
-                            p for p in (profile.get("givenName"), profile.get("familyName")) if p
-                        )
+                        profile_name = " ".join(p for p in (profile.get("givenName"), profile.get("familyName")) if p)
                         display = profile_name or display
                     members.append({"number": num, "name": display, "role": role})
                     if num == cfg.SIGNAL_NUMBER and role == "ADMINISTRATOR":

--- a/oden/web_handlers/group_handlers.py
+++ b/oden/web_handlers/group_handlers.py
@@ -54,7 +54,9 @@ async def groups_handler(request: web.Request) -> web.Response:
                 is_admin = False
                 for m in members_raw:
                     if isinstance(m, dict):
-                        num = m.get("number", "")
+                        # Some members (e.g. username-only contacts) have no phone
+                        # number — fall back to their Signal UUID so the row isn't blank.
+                        num = m.get("number") or m.get("uuid", "")
                         role = m.get("role", "DEFAULT")
                     elif isinstance(m, str):
                         num = m

--- a/oden/web_server.py
+++ b/oden/web_server.py
@@ -49,6 +49,7 @@ from oden.web_handlers.contact_handlers import (
 )
 from oden.web_handlers.group_handlers import (
     accept_invitation_handler,
+    create_group_handler,
     decline_invitation_handler,
     groups_handler,
     invitations_handler,
@@ -264,6 +265,7 @@ def create_app(setup_mode: bool = False) -> web.Application:
         app.router.add_get("/api/groups", groups_handler)
         app.router.add_post("/api/groups/refresh", refresh_groups_handler)
         app.router.add_post("/api/groups/update", update_group_handler)
+        app.router.add_post("/api/groups/create", create_group_handler)
         app.router.add_post("/api/config-save", config_save_handler)
         app.router.add_delete("/api/config/reset", config_reset_handler)
         app.router.add_post("/api/signal-cli/restart", restart_signal_cli_handler)

--- a/tests/test_config_db.py
+++ b/tests/test_config_db.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from oden.config_db import (
     init_db,
 )
+from oden.contacts_db import get_all_contacts, upsert_contacts_bulk
 from oden.groups_db import (
     delete_group,
     get_all_groups,
@@ -151,9 +152,9 @@ class TestResponsesCRUD(unittest.TestCase):
 
 
 class TestSchemaVersion(unittest.TestCase):
-    """Test that schema migration bumps version to 5."""
+    """Test that schema migration bumps version to 6."""
 
-    def test_schema_version_is_5(self):
+    def test_schema_version_is_6(self):
         import sqlite3
 
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
@@ -168,7 +169,7 @@ class TestSchemaVersion(unittest.TestCase):
         conn.close()
         db_path.unlink(missing_ok=True)
 
-        self.assertEqual(row[0], "5")
+        self.assertEqual(row[0], "6")
 
     def test_raw_messages_table_exists(self):
         import sqlite3
@@ -218,6 +219,23 @@ class TestSchemaVersion(unittest.TestCase):
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='groups'")
+        row = cursor.fetchone()
+        conn.close()
+        db_path.unlink(missing_ok=True)
+
+        self.assertIsNotNone(row)
+
+    def test_contacts_table_exists(self):
+        import sqlite3
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = Path(f.name)
+        db_path.unlink(missing_ok=True)
+        init_db(db_path)
+
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='contacts'")
         row = cursor.fetchone()
         conn.close()
         db_path.unlink(missing_ok=True)
@@ -286,7 +304,7 @@ class TestSchemaVersion(unittest.TestCase):
         try:
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM metadata WHERE key = 'schema_version'")
-            self.assertEqual(cursor.fetchone()[0], "5")
+            self.assertEqual(cursor.fetchone()[0], "6")
 
             cursor.execute("SELECT value FROM config WHERE key = 'append_window_minutes'")
             self.assertEqual(cursor.fetchone()[0], "45")
@@ -414,6 +432,60 @@ class TestGroupsCRUD(unittest.TestCase):
         groups = get_all_groups(self.db_path, account="+111")
         self.assertEqual(len(groups), 2)
         self.assertEqual(get_all_groups(self.db_path, account="+222"), [])
+
+
+class TestContactsCRUD(unittest.TestCase):
+    """Test CRUD operations for the contacts table."""
+
+    def setUp(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            self.db_path = Path(tmp.name)
+        self.db_path.unlink(missing_ok=True)
+        init_db(self.db_path)
+
+    def tearDown(self):
+        self.db_path.unlink(missing_ok=True)
+
+    def test_bulk_upsert_and_get_all(self):
+        contacts = [
+            {"number": "+461", "name": "Alice", "profile": {"givenName": "Alice"}},
+            {"number": "+462", "nickName": "Bob"},
+        ]
+        count = upsert_contacts_bulk(self.db_path, contacts, account="+460000")
+        self.assertEqual(count, 2)
+
+        stored = get_all_contacts(self.db_path, account="+460000")
+        self.assertEqual(len(stored), 2)
+        numbers = {c["number"] for c in stored}
+        self.assertEqual(numbers, {"+461", "+462"})
+        alice = next(c for c in stored if c["number"] == "+461")
+        self.assertEqual(alice["profile"]["givenName"], "Alice")
+
+    def test_bulk_upsert_updates_existing(self):
+        upsert_contacts_bulk(self.db_path, [{"number": "+461", "name": "Old"}], account="+460000")
+        upsert_contacts_bulk(self.db_path, [{"number": "+461", "name": "New"}], account="+460000")
+        stored = get_all_contacts(self.db_path, account="+460000")
+        self.assertEqual(len(stored), 1)
+        self.assertEqual(stored[0]["name"], "New")
+
+    def test_bulk_upsert_skips_missing_number(self):
+        count = upsert_contacts_bulk(self.db_path, [{"name": "No number"}], account="+460000")
+        self.assertEqual(count, 0)
+
+    def test_get_all_contacts_empty_db(self):
+        self.assertEqual(get_all_contacts(self.db_path), [])
+
+    def test_get_all_contacts_no_db(self):
+        self.db_path.unlink(missing_ok=True)
+        self.assertEqual(get_all_contacts(self.db_path), [])
+
+    def test_contacts_scoped_by_account(self):
+        upsert_contacts_bulk(self.db_path, [{"number": "+461", "name": "A"}], account="+111")
+        upsert_contacts_bulk(self.db_path, [{"number": "+461", "name": "B"}], account="+222")
+
+        self.assertEqual(len(get_all_contacts(self.db_path, account="+111")), 1)
+        self.assertEqual(get_all_contacts(self.db_path, account="+111")[0]["name"], "A")
+        self.assertEqual(len(get_all_contacts(self.db_path)), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_signal_listener.py
+++ b/tests/test_signal_listener.py
@@ -1,0 +1,91 @@
+"""Tests for periodic groups/contacts refresh in signal_listener.py."""
+
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from oden.app_state import AppState
+from oden.config_db import init_db
+from oden.contacts_db import get_all_contacts, upsert_contacts_bulk
+from oden.signal_listener import _periodic_groups_contacts_refresh, log_contacts
+
+
+class TestLogContacts(unittest.IsolatedAsyncioTestCase):
+    """log_contacts() must persist to DB on success and fall back to it on failure."""
+
+    def setUp(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            self.db_path = Path(tmp.name)
+        self.db_path.unlink(missing_ok=True)
+        init_db(self.db_path)
+        self.app_state = AppState()
+
+    def tearDown(self):
+        self.db_path.unlink(missing_ok=True)
+
+    # oden.signal_listener imports `cfg` locally (`from oden import config as cfg`)
+    # inside each function, so patches must target oden.config's attributes directly.
+    @unittest.mock.patch("oden.signal_listener.get_app_state")
+    @unittest.mock.patch("oden.config.SIGNAL_NUMBER", "+460000")
+    async def test_persists_contacts_on_successful_rpc(self, mock_get_app_state):
+        with unittest.mock.patch("oden.config.CONFIG_DB", self.db_path):
+            self.app_state.send_jsonrpc = unittest.mock.AsyncMock(
+                return_value={"result": [{"number": "+461", "name": "Alice"}]}
+            )
+            mock_get_app_state.return_value = self.app_state
+
+            await log_contacts()
+
+        self.assertEqual(self.app_state.contacts["+461"]["name"], "Alice")
+        stored = get_all_contacts(self.db_path, account="+460000")
+        self.assertEqual(len(stored), 1)
+        self.assertEqual(stored[0]["number"], "+461")
+
+    @unittest.mock.patch("oden.signal_listener.get_app_state")
+    @unittest.mock.patch("oden.config.SIGNAL_NUMBER", "+460000")
+    async def test_falls_back_to_database_when_rpc_fails(self, mock_get_app_state):
+        upsert_contacts_bulk(self.db_path, [{"number": "+462", "name": "Cached Bob"}], account="+460000")
+
+        with unittest.mock.patch("oden.config.CONFIG_DB", self.db_path):
+            self.app_state.send_jsonrpc = unittest.mock.AsyncMock(side_effect=Exception("connection lost"))
+            mock_get_app_state.return_value = self.app_state
+
+            await log_contacts()
+
+        self.assertEqual(self.app_state.contacts["+462"]["name"], "Cached Bob")
+
+
+class TestPeriodicRefresh(unittest.IsolatedAsyncioTestCase):
+    """The background refresh loop must call log_groups + log_contacts each tick."""
+
+    @unittest.mock.patch("oden.signal_listener.log_contacts", new_callable=unittest.mock.AsyncMock)
+    @unittest.mock.patch("oden.signal_listener.log_groups", new_callable=unittest.mock.AsyncMock)
+    @unittest.mock.patch("oden.signal_listener.asyncio.sleep", new_callable=unittest.mock.AsyncMock)
+    async def test_refreshes_groups_and_contacts_each_tick(self, mock_sleep, mock_log_groups, mock_log_contacts):
+        # Run exactly two iterations, then break out via a sentinel exception.
+        mock_sleep.side_effect = [None, RuntimeError("stop loop")]
+
+        with self.assertRaises(RuntimeError):
+            await _periodic_groups_contacts_refresh(writer=unittest.mock.Mock())
+
+        self.assertEqual(mock_log_groups.await_count, 1)
+        self.assertEqual(mock_log_contacts.await_count, 1)
+
+    @unittest.mock.patch("oden.signal_listener.log_contacts", new_callable=unittest.mock.AsyncMock)
+    @unittest.mock.patch(
+        "oden.signal_listener.log_groups", new_callable=unittest.mock.AsyncMock, side_effect=Exception("boom")
+    )
+    @unittest.mock.patch("oden.signal_listener.asyncio.sleep", new_callable=unittest.mock.AsyncMock)
+    async def test_a_failed_refresh_does_not_kill_the_loop(self, mock_sleep, mock_log_groups, mock_log_contacts):
+        mock_sleep.side_effect = [None, RuntimeError("stop loop")]
+
+        with self.assertRaises(RuntimeError):
+            await _periodic_groups_contacts_refresh(writer=unittest.mock.Mock())
+
+        # Loop must have survived the exception and reached the second sleep.
+        self.assertEqual(mock_sleep.await_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_crud.py
+++ b/tests/test_web_crud.py
@@ -446,3 +446,58 @@ class TestGroupsHandlerResponse(AioHTTPTestCase):
         self.assertEqual(len(data["groups"]), 2)
 
         app_state.update_groups([])
+
+
+class TestCreateGroupHandler(AioHTTPTestCase):
+    """Test POST /api/groups/create."""
+
+    async def get_application(self):
+        return create_app(setup_mode=False)
+
+    async def test_create_group_requires_name(self):
+        """Missing name returns 400 without touching signal-cli."""
+        resp = await self.client.post("/api/groups/create", json={"name": ""})
+        self.assertEqual(resp.status, 400)
+        data = await resp.json()
+        self.assertFalse(data["success"])
+
+    @unittest.mock.patch("oden.web_handlers.group_handlers.get_app_state")
+    @unittest.mock.patch("oden.web_handlers._helpers.get_app_state")
+    @unittest.mock.patch("oden.web_handlers.group_handlers.upsert_groups_bulk")
+    @unittest.mock.patch("oden.web_handlers.group_handlers.cfg")
+    async def test_create_group_sends_create_group_rpc(
+        self,
+        mock_cfg,
+        _mock_upsert,
+        mock_helpers_state,
+        mock_handler_state,
+    ):
+        """A valid name + members sends createGroup then refreshes the cache."""
+        mock_cfg.SIGNAL_NUMBER = "+460000"
+
+        state = unittest.mock.Mock()
+        state.writer = object()
+        state.send_jsonrpc = unittest.mock.AsyncMock(
+            side_effect=[
+                {"result": {"groupId": "abc"}},
+                {"result": []},
+            ]
+        )
+        mock_helpers_state.return_value = state
+        mock_handler_state.return_value = state
+
+        resp = await self.client.post(
+            "/api/groups/create",
+            json={"name": "Ny grupp", "member": ["+461"]},
+        )
+
+        self.assertEqual(resp.status, 200)
+        data = await resp.json()
+        self.assertTrue(data["success"])
+
+        first_call = state.send_jsonrpc.call_args_list[0]
+        self.assertEqual(first_call.args[0], "createGroup")
+        self.assertEqual(
+            first_call.kwargs["params"],
+            {"account": "+460000", "name": "Ny grupp", "member": ["+461"]},
+        )

--- a/tests/test_web_crud.py
+++ b/tests/test_web_crud.py
@@ -501,3 +501,38 @@ class TestCreateGroupHandler(AioHTTPTestCase):
             first_call.kwargs["params"],
             {"account": "+460000", "name": "Ny grupp", "member": ["+461"]},
         )
+
+    @unittest.mock.patch("oden.web_handlers.group_handlers.get_app_state")
+    @unittest.mock.patch("oden.web_handlers.group_handlers.cfg")
+    async def test_create_group_reports_signal_cli_error_instead_of_success(
+        self,
+        mock_cfg,
+        mock_handler_state,
+    ):
+        """A JSON-RPC error response must surface as a failure, not a false 'success'.
+
+        signal-cli responds with a non-None dict containing an "error" key (no
+        "result") when createGroup fails server-side — e.g. permission or
+        rate-limit issues. Previously the handler only checked `result is None`,
+        so this case was reported as success even though no group was created.
+        """
+        mock_cfg.SIGNAL_NUMBER = "+460000"
+
+        state = unittest.mock.Mock()
+        state.writer = object()
+        state.send_jsonrpc = unittest.mock.AsyncMock(
+            return_value={"error": {"code": -1, "message": "Group creation failed"}}
+        )
+        mock_handler_state.return_value = state
+
+        resp = await self.client.post(
+            "/api/groups/create",
+            json={"name": "Ny grupp"},
+        )
+
+        self.assertEqual(resp.status, 502)
+        data = await resp.json()
+        self.assertFalse(data["success"])
+        self.assertEqual(data["error"], "Group creation failed")
+        # Must not have gone on to refresh/persist a group that was never created.
+        self.assertEqual(state.send_jsonrpc.call_count, 1)


### PR DESCRIPTION
## Summary
- Grupper-fliken visade tidigare bara namn + antal medlemmar per grupp; medlemslistan syntes bara för admins via redigeringsmodalen.
- Varje grupp visar nu en expanderbar (`<details>`) trädlista med nummer, namn (inkl. fallback till Signal-profilnamn/UUID), ev. adminmärke, blockerad-status och kontaktanteckning — synlig för alla.
- Nytt: formulär för att **skapa grupper** direkt från webb-GUI:t, med möjlighet att bjuda in kontakter via kryssrutor eller manuellt inmatade nummer (`POST /api/groups/create` → signal-cli:s `createGroup`-RPC).
- **Buggfix:** `create_group_handler`/`update_group_handler` kollade bara om signal-cli svarade alls, inte om svaret innehöll ett JSON-RPC `error`-fält — en avvisad `createGroup`/`updateGroup` loggades och rapporterades som "skapad"/"uppdaterad" trots att inget faktiskt hände. Felmeddelandet från signal-cli returneras nu istället.
- **Nytt:** grupper och kontakter hämtas nu periodiskt (var 15:e minut) från signal-cli oavsett meddelandetrafik, inte bara vid uppstart eller manuell "Uppdatera"-tryckning. Kontakter persisteras nu även till databasen (ny `contacts`-tabell, schema v6) för första gången — tidigare fanns bara en in-memory-cache som förlorades vid omstart.

## Test plan
- [x] `pytest` — 316 passed (nya tester för gruppskapande-felhantering, contacts-tabellens CRUD, och den periodiska refresh-looben)
- [ ] Starta appen, öppna Grupper-fliken, verifiera medlemsträdet och att "Skapa grupp"-formuläret listar kontakter och skapar en grupp
- [ ] Verifiera i loggen att grupper/kontakter uppdateras periodiskt utan att "Uppdatera" trycks