### PR TITLE
fix(pipelines): apply generic pipeline settings live, not just after restart

### DIFF
--- a/oden/web_handlers/pipeline_handlers.py
+++ b/oden/web_handlers/pipeline_handlers.py
@@ -15,6 +15,7 @@ from typing import Any
 from aiohttp import web
 
 from oden import config as cfg
+from oden.config import reload_config
 from oden.config_db import set_config_value
 from oden.pipeline_orchestrator import _GenericPipeline
 from oden.pipeline_settings import (
@@ -124,7 +125,10 @@ def _get_pipeline_settings() -> dict[str, Any]:
 
 def _save_pipeline_settings(settings: dict[str, Any]) -> None:
     set_config_value(cfg.CONFIG_DB, "pipeline_settings", settings)
-    cfg.PIPELINE_SETTINGS = settings
+    # reload_config() re-derives cfg.AUTO_REACTION_ENABLED/EMOJI, cfg.AUTO_READ_RECEIPT_ENABLED
+    # and cfg.FILENAME_FORMAT from the generic_template settings — a plain assignment to
+    # cfg.PIPELINE_SETTINGS leaves those stale until the next full reload.
+    reload_config()
 
 
 @handle_errors("listing pipelines")

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -455,6 +455,29 @@ class TestPipelineManagementAPI(AioHTTPTestCase):
             self.assertEqual(data["config"]["mode"], "blacklist")
             self.assertEqual(data["config"]["groups"], ["Alpha", "Bravo"])
 
+    async def test_update_pipeline_config_generic_template_applies_auto_reaction_live(self):
+        """Toggling auto_reaction_enabled must take effect immediately (cfg.AUTO_REACTION_ENABLED),
+        not just update cfg.PIPELINE_SETTINGS — otherwise the change requires an app restart."""
+        import oden.config as cfg
+
+        resp = await self.client.patch(
+            "/api/pipelines/generic_template/config",
+            json={"config": {"auto_reaction_enabled": True, "auto_reaction_emoji": "👍"}},
+        )
+
+        self.assertEqual(resp.status, 200)
+        data = await resp.json()
+        self.assertTrue(data["success"])
+        self.assertTrue(data["config"]["auto_reaction_enabled"])
+        self.assertTrue(cfg.AUTO_REACTION_ENABLED)
+        self.assertEqual(cfg.AUTO_REACTION_EMOJI, "👍")
+
+        # Clean up so this doesn't leak into other tests sharing the test config DB.
+        await self.client.patch(
+            "/api/pipelines/generic_template/config",
+            json={"config": {"auto_reaction_enabled": False, "auto_reaction_emoji": "✅"}},
+        )
+
     async def test_update_pipeline_config_seven_s_subdir_toggle(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "config.db"


### PR DESCRIPTION
## Summary
- Root cause: `update_pipeline_config` (`PATCH /api/pipelines/{name}/config`) only updated `cfg.PIPELINE_SETTINGS`. `_send_reaction()`/`_send_read_receipt()` in `oden/processing.py` don't read that — they read `cfg.AUTO_REACTION_ENABLED`, `cfg.AUTO_REACTION_EMOJI`, `cfg.AUTO_READ_RECEIPT_ENABLED`, which are separate globals only recomputed inside `cfg.reload_config()`.
- Result: toggling "Auto-reaktion" (or the read-receipt / emoji setting) for the generic pipeline in the web GUI had no effect until the app was restarted.
- Fix: `_save_pipeline_settings()` now calls `reload_config()` after persisting, same pattern the main config-save endpoint (`config_handlers.py`) already uses.

## Test plan
- [x] `pytest` — 302 passed, including a new regression test that PATCHes `/api/pipelines/generic_template/config` with `auto_reaction_enabled: true` and asserts `cfg.AUTO_REACTION_ENABLED` flips immediately (previously failed without the fix)
- [ ] Manual: toggle Auto-reaktion on for the generic pipeline in the Pipelines tab, send a message, confirm a reaction is sent without restarting the app